### PR TITLE
refactor: replace relative layout with framelayout

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,7 +30,7 @@
 
         </android.support.design.widget.AppBarLayout>
 
-        <RelativeLayout
+        <FrameLayout
             android:layout_marginTop="20dp"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
If a layout is just to add a fragment then its better to add framelayout instead of other layout