### PR TITLE
Improve PDF conversion performance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Hurray! PDF files of selected images are created.
 + [Morphing Button](https://github.com/dmytrodanylyk/android-morphing-button)
 + [TedPicker](https://github.com/ParkSangGwon/TedPicker)
 + [Material Dialogs](https://github.com/afollestad/material-dialogs)
++ [Compressor](https://github.com/zetbaitsu/Compressor)
 
 #### Code & Issues
 If you are a developer and you wish to contribute to the app please fork the project

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,5 +44,6 @@ dependencies {
         transitive = true
     }
     compile 'com.jakewharton:butterknife:8.4.0'
+    compile 'id.zelory:compressor:2.1.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.4.0'
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
@@ -12,7 +12,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
-import android.provider.MediaStore;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DimenRes;
 import android.support.annotation.IntegerRes;
@@ -36,12 +35,12 @@ import com.itextpdf.text.Rectangle;
 import com.itextpdf.text.pdf.PdfWriter;
 import com.theartofdev.edmodo.cropper.CropImage;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 
 import butterknife.ButterKnife;
+import id.zelory.compressor.Compressor;
 import swati4star.createpdf.R;
 import swati4star.createpdf.adapter.ViewFilesAdapter;
 
@@ -404,11 +403,10 @@ public class HomeFragment extends Fragment {
 
                 for (int i = 0; i < imagesUri.size(); i++) {
 
-                    Bitmap bmp = MediaStore.Images.Media.getBitmap(
-                            activity.getContentResolver(), Uri.fromFile(new File(imagesUri.get(i))));
-                    ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                    bmp.compress(Bitmap.CompressFormat.PNG, 70, stream);
-
+                    Bitmap bmp = new Compressor(getContext())
+                            .setQuality(70)
+                            .setCompressFormat(Bitmap.CompressFormat.PNG)
+                            .compressToBitmap(new File(imagesUri.get(i)));
 
                     image = Image.getInstance(imagesUri.get(i));
 


### PR DESCRIPTION
Change to address the following issue: https://github.com/Swati4star/Images-to-PDF/issues/53.

This change seeks to improve the PDF conversion performance by using a different image compression library.  I performed timing logging for the creation of the PDF and found the following results using the same file.

1 Image (3.74 MB):
- Current App: 1035 ms (average)
- Proposed Change: 556 ms (average)