### PR TITLE
Bug - View files show nothing in a particular case #100

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -302,7 +302,7 @@ public class ViewFilesFragment extends Fragment
         private void populateListView() {
             ArrayList<File> pdfFiles = new ArrayList<>();
             final File[] files = getOrCreatePdfDirectory().listFiles();
-            if (files == null)
+            if (files.length == 0)
                 Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
                         R.string.snackbar_no_pdfs,
                         Snackbar.LENGTH_LONG).show();

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -26,6 +26,8 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
+import org.w3c.dom.Text;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -302,10 +304,12 @@ public class ViewFilesFragment extends Fragment
         private void populateListView() {
             ArrayList<File> pdfFiles = new ArrayList<>();
             final File[] files = getOrCreatePdfDirectory().listFiles();
-            if (files.length == 0)
+            if (files.length == 0){
+                setEmptyStateVisible();
                 Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
                         R.string.snackbar_no_pdfs,
                         Snackbar.LENGTH_LONG).show();
+            }
             else {
                 pdfFiles = getPdfsFromPdfFolder();
             }

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -302,13 +302,12 @@ public class ViewFilesFragment extends Fragment
         private void populateListView() {
             ArrayList<File> pdfFiles = new ArrayList<>();
             final File[] files = getOrCreatePdfDirectory().listFiles();
-            if (files.length == 0){
+            if (files.length == 0) {
                 setEmptyStateVisible();
                 Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
                         R.string.snackbar_no_pdfs,
                         Snackbar.LENGTH_LONG).show();
-            }
-            else {
+            } else {
                 pdfFiles = getPdfsFromPdfFolder();
             }
             Log.v("done", "adding");

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -26,8 +26,6 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
-import org.w3c.dom.Text;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;


### PR DESCRIPTION
Its better to use `files.length == 0` rather than `files == null`.

- After this fix, the user will get a snackbar which will show that there are "_No PDFs right now_".