### PR TITLE
Change the word "Choice Image" on the screen when clicking an image. #115

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
@@ -31,6 +31,7 @@ import android.view.ViewGroup;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.dd.morphingbutton.MorphingButton;
+import com.gun0912.tedpicker.Config;
 import com.gun0912.tedpicker.ImagePickerActivity;
 import com.itextpdf.text.Document;
 import com.itextpdf.text.Image;
@@ -230,6 +231,10 @@ public class HomeFragment extends Fragment implements EnhancementOptionsAdapter.
      * Opens ImagePickerActivity to select Images
      */
     private void selectImages() {
+        Config config = new Config();
+        config.setToolbarTitleRes(R.string.image_picker_activity_toolbar_title);
+
+        ImagePickerActivity.setConfig(config);
         Intent intent = new Intent(mActivity, ImagePickerActivity.class);
 
         //add to intent the URIs of the already selected images

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -78,4 +78,6 @@
     <string name="rate_dialog_text">If you enjoy this app, please take a moment to rate this app. It won\'t take more than a minute. Thank you for your support! :)</string>
     <string name="rate_title">Rate us!</string>
     <string name="feedback_chooser">Send mail…</string>
+
+    <string name="image_picker_activity_toolbar_title">Select Image</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,6 +49,9 @@
     <string name="snackbar_no_pdf_app">No hay app para abrir ficheros PDF</string>
     <string name="open_file">Abrir Firchero</string>
     <string name="sort">Ordenar</string>
+    <string name="file_already_exists">El archivo con el mismo nombre ya existe. ¿Desea sobrescribir el archivo existente?</string>
+    <string name="yes">Sí</string>
+    <string name="no">No</string>
 
     <string name="set_password">Configurar la clave</string>
     <string name="enter_password">Introducir la contraseña</string>
@@ -79,5 +82,5 @@
     <string name="rate_title">Rate us!</string>
     <string name="feedback_chooser">Send mail…</string>
 
-    <string name="image_picker_activity_toolbar_title">Select Image</string>
+    <string name="image_picker_activity_toolbar_title">Select Images</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -48,6 +48,9 @@
     <string name="snackbar_no_pdf_app">Il  n\'y a pas d\'app pour lire fichiers PDF</string>
     <string name="open_file">Ouvrir Fichier</string>
     <string name="sort">Trier</string>
+    <string name="file_already_exists">Le fichier portant le même nom existe déjà. Voulez-vous remplacer le fichier existant?</string>
+    <string name="yes">Oui</string>
+    <string name="no">Non</string>
 
     <string name="set_password">Définir le mot</string>
     <string name="enter_password">Entrer le mot de passe</string>
@@ -78,5 +81,5 @@
     <string name="rate_title">Rate us!</string>
     <string name="feedback_chooser">Send mail…</string>
 
-    <string name="image_picker_activity_toolbar_title">Select Image</string>
+    <string name="image_picker_activity_toolbar_title">Select Images</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -77,4 +77,6 @@
     <string name="rate_dialog_text">If you enjoy this app, please take a moment to rate this app. It won\'t take more than a minute. Thank you for your support! :)</string>
     <string name="rate_title">Rate us!</string>
     <string name="feedback_chooser">Send mail…</string>
+
+    <string name="image_picker_activity_toolbar_title">Select Image</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -49,6 +49,9 @@
     <string name="snackbar_no_pdf_app">No app to read PDF File</string>
     <string name="open_file">Open File</string>
     <string name="sort">Sort</string>
+    <string name="file_already_exists">同じ名前のファイルが既に存在します。既存のファイルを上書きしますか？</string>
+    <string name="yes">はい</string>
+    <string name="no">いいえ</string>
 
     <string name="set_password">パスワードを設定してください</string>
     <string name="enter_password">パスワードを入力する</string>
@@ -79,5 +82,5 @@
     <string name="rate_title">Rate us!</string>
     <string name="feedback_chooser">Send mail…</string>
 
-    <string name="image_picker_activity_toolbar_title">Select Image</string>
+    <string name="image_picker_activity_toolbar_title">Select Images</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -78,4 +78,6 @@
     <string name="rate_dialog_text">If you enjoy this app, please take a moment to rate this app. It won\'t take more than a minute. Thank you for your support! :)</string>
     <string name="rate_title">Rate us!</string>
     <string name="feedback_chooser">Send mail…</string>
+
+    <string name="image_picker_activity_toolbar_title">Select Image</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,9 @@
     <string name="snackbar_no_pdf_app">No app to read PDF File</string>
     <string name="open_file">Open File</string>
     <string name="sort">Sort</string>
+    <string name="file_already_exists">File with the same name already exists. Do you want to overwrite the existing file?</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
 
     <string name="set_password">Set Password</string>
     <string name="enter_password">Enter Password</string>
@@ -99,5 +102,5 @@
     <string name="feedback_chooser">"Send mail…"</string>
 
     <!--ImagePickerActivity Strings-->
-    <string name="image_picker_activity_toolbar_title">Select Image</string>
+    <string name="image_picker_activity_toolbar_title">Select Images</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,5 +98,6 @@
     <string name="snackbar_no_email_clients">There are no email clients installed.</string>
     <string name="feedback_chooser">"Send mail…"</string>
 
-
+    <!--ImagePickerActivity Strings-->
+    <string name="image_picker_activity_toolbar_title">Select Image</string>
 </resources>


### PR DESCRIPTION
Before this fix, whenever we went to "Select Images" option, we saw "Choice Image" in the title bar.

![before](https://user-images.githubusercontent.com/22465432/41860032-35c0f762-78bb-11e8-869a-38359a7b8a86.jpeg)

After this fix, the title bar will say "Select Image", below is the screenshot.

![after](https://user-images.githubusercontent.com/22465432/41860194-9ed168fe-78bb-11e8-9e34-db9a258e5d10.jpeg)

@Swati4star This time I created a new branch before creating this pull request.

