### PR TITLE
Toast when no images #143

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
@@ -227,9 +227,9 @@ public class HomeFragment extends Fragment implements EnhancementOptionsAdapter.
             ArrayList<Uri> imageUris = data.getParcelableArrayListExtra(ImagePickerActivity.EXTRA_IMAGE_URIS);
             for (Uri uri : imageUris)
                 mTempUris.add(uri.getPath());
-            Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
+            if (imageUris.size()>0){Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
                     R.string.snackbar_images_added,
-                    Snackbar.LENGTH_LONG).show();
+                    Snackbar.LENGTH_LONG).show();}
             mMorphButtonUtility.morphToSquare(mCreatePdf, mMorphButtonUtility.integer());
             mOpenPdf.setVisibility(View.GONE);
 


### PR DESCRIPTION
Snackbar only shows "Images added" if images are selected

# Description

Earlier when even no images were selected the images added snackbar was called for. I has been fixed by checking the size of images array.
Fixes #143 

## Type of change
Just put an x in the [] which are valid.
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
