### PR TITLE
Maintain Aspect Ratio of images

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
@@ -125,14 +125,8 @@ public class CreatePdf extends AsyncTask<String, String, String> {
                 BitmapFactory.Options bmOptions = new BitmapFactory.Options();
                 Bitmap bitmap = BitmapFactory.decodeFile(mImagesUri.get(i), bmOptions);
 
-                if (bitmap.getWidth() > documentRect.getWidth()
-                        || bitmap.getHeight() > documentRect.getHeight()) {
-                    //bitmap is larger than page,so set bitmap's size similar to the whole page
-                    image.scaleAbsolute(documentRect.getWidth(), documentRect.getHeight());
-                } else {
-                    //bitmap is smaller than page, so add bitmap simply.
-                    image.scaleAbsolute(bitmap.getWidth(), bitmap.getHeight());
-                }
+                Rectangle imageSize = ImageUtils.calculateFitSize(bitmap.getWidth(), bitmap.getHeight(), documentRect);
+                image.scaleAbsolute(imageSize);
 
                 Log.v("Stage 6", "Image mPath adding");
 

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -1,0 +1,31 @@
+package swati4star.createpdf.util;
+
+import com.itextpdf.text.Rectangle;
+
+public class ImageUtils {
+
+    /**
+     * Calculates the optimum size for an image, such that it scales to fit whilst retaining its aspect ratio
+     *
+     * @param originalWidth the original width of the image
+     * @param originalHeight the original height of the image
+     * @param documentSize a rectangle specifying the width and height that the image must fit within
+     * @return a rectangle that provides the scaled width and height of the image
+     */
+    public static Rectangle calculateFitSize(float originalWidth, float originalHeight, Rectangle documentSize) {
+        float widthChange = (originalWidth - documentSize.getWidth()) / originalWidth;
+        float heightChange = (originalHeight - documentSize.getHeight()) / originalHeight;
+
+        float changeFactor;
+        if (widthChange >= heightChange) {
+            changeFactor = widthChange;
+        } else {
+            changeFactor = heightChange;
+        }
+        float newWidth = originalWidth - (originalWidth * changeFactor);
+        float newHeight = originalHeight - (originalHeight * changeFactor);
+
+        return new Rectangle(Math.abs((int) newWidth), Math.abs((int) newHeight));
+    }
+
+}


### PR DESCRIPTION
# Description
When adding an image, it will resize, keeping the aspect ratio.
I created a new method to calculate the correct image size, and called it from the correct place.

Fixes #93

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

NB The checkstyle reports two errors, but these are in the auto-generated code, and as such I ignored them.
The new method has also been tested locally using unit tests - I would have added them but there is currently no structure for this.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
