### PR TITLE
fixed issue #283

### DIFF
--- a/app/src/main/java/swati4star/createpdf/adapter/HistoryAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/HistoryAdapter.java
@@ -19,10 +19,13 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHist
 
     private final List<History> mHistoryList;
     private final Activity mActivity;
+    private final OnClickListener mOnClickListener;
 
-    public HistoryAdapter(Activity mActivity, List<History> mHistoryList) {
+
+    public HistoryAdapter(Activity mActivity, List<History> mHistoryList, OnClickListener mOnClickListener) {
         this.mHistoryList = mHistoryList;
         this.mActivity = mActivity;
+        this.mOnClickListener = mOnClickListener;
     }
 
     @NonNull
@@ -56,7 +59,7 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHist
         return mHistoryList == null ? 0 : mHistoryList.size();
     }
 
-    public class ViewHistoryHolder extends RecyclerView.ViewHolder {
+    public class ViewHistoryHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         @BindView(R.id.fileName)
         TextView mFilename;
@@ -68,6 +71,16 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHist
         ViewHistoryHolder(View itemView) {
             super(itemView);
             ButterKnife.bind(this, itemView);
+            itemView.setOnClickListener(this);
         }
+
+        @Override
+        public void onClick(View view) {
+            mOnClickListener.onItemClick(mHistoryList.get(getAdapterPosition()).getFilePath());
+        }
+    }
+
+    public interface OnClickListener {
+        void onItemClick(String path);
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java
@@ -2,10 +2,7 @@ package swati4star.createpdf.fragment;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -14,7 +11,6 @@ import android.support.constraint.ConstraintLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
-import android.support.v4.content.FileProvider;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -38,6 +34,7 @@ import swati4star.createpdf.R;
 import swati4star.createpdf.adapter.HistoryAdapter;
 import swati4star.createpdf.database.AppDatabase;
 import swati4star.createpdf.database.History;
+import swati4star.createpdf.util.FileUtils;
 import swati4star.createpdf.util.ViewFilesDividerItemDecoration;
 
 public class HistoryFragment extends Fragment implements HistoryAdapter.OnClickListener {
@@ -115,23 +112,10 @@ public class HistoryFragment extends Fragment implements HistoryAdapter.OnClickL
 
     @Override
     public void onItemClick(String path) {
+        FileUtils fileUtils=new FileUtils(mActivity);
         File file = new File(path);
         if (file.exists()) {
-            Intent target = new Intent(Intent.ACTION_VIEW);
-            Uri uri = FileProvider.getUriForFile(mActivity, "com.swati4star.shareFile", file);
-
-            target.setDataAndType(uri, getString(R.string.pdf_type));
-            target.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-            target.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-            Intent intent = Intent.createChooser(target, getString(R.string.open_file));
-            try {
-                startActivity(intent);
-            } catch (ActivityNotFoundException e) {
-                Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
-                        R.string.snackbar_no_pdf_app,
-                        Snackbar.LENGTH_LONG).show();
-            }
+           fileUtils.openFile(path);
         } else {
             Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
                     R.string.pdf_does_not_exist_message,

--- a/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java
@@ -112,10 +112,10 @@ public class HistoryFragment extends Fragment implements HistoryAdapter.OnClickL
 
     @Override
     public void onItemClick(String path) {
-        FileUtils fileUtils=new FileUtils(mActivity);
+        FileUtils fileUtils = new FileUtils(mActivity);
         File file = new File(path);
         if (file.exists()) {
-           fileUtils.openFile(path);
+            fileUtils.openFile(path);
         } else {
             Snackbar.make(Objects.requireNonNull(mActivity).findViewById(android.R.id.content),
                     R.string.pdf_does_not_exist_message,

--- a/app/src/main/res/layout/layout_item_history.xml
+++ b/app/src/main/res/layout/layout_item_history.xml
@@ -1,47 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.balysv.materialripple.MaterialRippleLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:baselineAligned="false"
-    android:orientation="horizontal"
-    android:weightSum="7">
+    android:layout_height="wrap_content">
 
     <LinearLayout
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="5"
-        android:gravity="center_vertical"
-        android:orientation="vertical">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:weightSum="7">
 
-        <TextView
-            android:id="@+id/fileName"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:padding="8dp"
-            android:textSize="18sp" />
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="5"
+            android:gravity="center_vertical"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/fileName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:padding="8dp"
+                android:textSize="18sp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="2"
+            android:orientation="vertical"
+            android:weightSum="2">
+
+            <TextView
+                android:id="@+id/operationDate"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:padding="8dp" />
+
+            <TextView
+                android:id="@+id/operationType"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:padding="8dp" />
+
+        </LinearLayout>
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="2"
-        android:orientation="vertical"
-        android:weightSum="2">
-
-        <TextView
-            android:id="@+id/operationDate"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:padding="8dp" />
-
-        <TextView
-            android:id="@+id/operationType"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:padding="8dp" />
-
-    </LinearLayout>
-</LinearLayout>
+</com.balysv.materialripple.MaterialRippleLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -241,4 +241,5 @@
     <string name="arrow_down">Arrow Down</string>
     <string name="rearrange_images">Rearrange Images</string>
     <string name="rearrange_text">Rearrange</string>
+    <string name="pdf_does_not_exist_message">The PDF doesn\'t exist.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -242,4 +242,5 @@
     <string name="arrow_down">Arrow Down</string>
     <string name="rearrange_images">Rearrange Images</string>
     <string name="rearrange_text">Rearrange</string>
+    <string name="pdf_does_not_exist_message">The PDF doesn\'t exist.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -240,4 +240,5 @@
     <string name="arrow_down">Arrow Down</string>
     <string name="rearrange_images">Rearrange Images</string>
     <string name="rearrange_text">Rearrange</string>
+    <string name="pdf_does_not_exist_message">The PDF doesn\'t exist.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,5 +299,6 @@
     <string name="arrow_down">Arrow Down</string>
     <string name="rearrange_images">Rearrange Images</string>
     <string name="rearrange_text">Rearrange</string>
+    <string name="pdf_does_not_exist_message">The PDF doesn\'t exist.</string>
 
 </resources>


### PR DESCRIPTION
# Description

open pdf when selected in history fragment.
![image](https://user-images.githubusercontent.com/18503975/43312568-5156045a-91ab-11e8-89b4-74a899da2ea1.png)


![image](https://user-images.githubusercontent.com/18503975/43312576-56693034-91ab-11e8-81e1-ce9d25072e3f.png)



Fixes #283

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`
