### PR TITLE
Fix for #344

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
@@ -363,7 +363,7 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.finish:
-                passUris(mImagepaths);
+                onFinishClick();
                 return true;
             case android.R.id.home:
                 new MaterialDialog.Builder(this)
@@ -375,6 +375,20 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
                 return true;
             default:
                 return super.onOptionsItemSelected(item);
+        }
+    }
+
+    private void onFinishClick() {
+        if (mClicked) {
+            passUris(mImagepaths);
+        } else {
+            new MaterialDialog.Builder(this)
+                    .onPositive((dialog, which) -> passUris(mImagepaths))
+                    .title(R.string.warning)
+                    .content(R.string.filter_on_finish_click_warning_message)
+                    .positiveText(R.string.ok)
+                    .negativeText(R.string.cancel)
+                    .show();
         }
     }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -253,4 +253,5 @@
     <string name="extract_images">Extract Images</string>
     <string name="extract_images_failed">We couldn\'t find any images in the selected PDF.</string>
     <string name="extract_images_success">We found %1$d image(s) in the selected PDF. They have been saved in the PDF Files folder in root directory.</string>
+    <string name="filter_on_finish_click_warning_message">The filter on current image is not saved. Do you want to continue without saving?</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -254,4 +254,5 @@
     <string name="extract_images">Extract Images</string>
     <string name="extract_images_failed">We couldn\'t find any images in the selected PDF.</string>
     <string name="extract_images_success">We found %1$d image(s) in the selected PDF. They have been saved in the PDF Files folder in root directory.</string>
+    <string name="filter_on_finish_click_warning_message">The filter on current image is not saved. Do you want to continue without saving?</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -252,4 +252,5 @@
     <string name="extract_images">Extract Images</string>
     <string name="extract_images_failed">We couldn\'t find any images in the selected PDF.</string>
     <string name="extract_images_success">We found %1$d image(s) in the selected PDF. They have been saved in the PDF Files folder in root directory.</string>
+    <string name="filter_on_finish_click_warning_message">The filter on current image is not saved. Do you want to continue without saving?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,4 +313,5 @@
     <string name="border_dialog_title">Enter border width in units (Default is 0) : </string>
     <string name="select_as">Select as:</string>
     <string name="filter_not_saved">Image could not be saved</string>
+    <string name="filter_on_finish_click_warning_message">The filter on current image is not saved. Do you want to continue without saving?</string>
 </resources>


### PR DESCRIPTION
# Description
filter screen
on finish click showing warning dialog if the filter is not saved.

![image](https://user-images.githubusercontent.com/18503975/44090667-9d8ad18e-9fe8-11e8-97ce-daa141cd0832.png)


Fixes #344

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`