### PR TITLE
Bug fixed of home scrolling down

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -6,12 +6,12 @@
     android:background="#eceff1"
     android:orientation="vertical"
     tools:context=".fragment.ImageToPdfFragment"
-    tools:ignore="Overdraw">
+    tools:ignore="Overdraw"
+    android:focusableInTouchMode="true">
 
     <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:focusableInTouchMode="true">
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #412, need to add android:focusableInTouchMode="true" to parent layout, not child.

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)