### PR TITLE
Add option grayscale pdf

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
     // Picasso, image editor, image cropper
     implementation 'com.squareup.picasso:picasso:2.5.2'
+    compile 'jp.wasabeef:picasso-transformations:2.2.1'
     implementation 'ja.burhanrashid52:photoeditor:0.2.1'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 
     // Picasso, image editor, image cropper
     implementation 'com.squareup.picasso:picasso:2.5.2'
-    compile 'jp.wasabeef:picasso-transformations:2.2.1'
+    implementation 'jp.wasabeef:picasso-transformations:2.2.1'
     implementation 'ja.burhanrashid52:photoeditor:0.2.1'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
 

--- a/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java
@@ -611,10 +611,10 @@ public class ImageToPdfFragment extends Fragment implements OnItemClickListner,
                     bitmap.compress(Bitmap.CompressFormat.JPEG, 100, ostream);
                     ostream.flush();
                     ostream.close();
+                    mImagesUri.add(url);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
-                mImagesUri.add(url);
             }
 
             @Override

--- a/app/src/main/java/swati4star/createpdf/util/ImageEnhancementOptionsUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageEnhancementOptionsUtils.java
@@ -1,6 +1,9 @@
 package swati4star.createpdf.util;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
 
 import java.util.ArrayList;
 
@@ -50,6 +53,14 @@ public class ImageEnhancementOptionsUtils {
         options.add(new EnhancementOptionsEntity(
                 context.getResources().getDrawable(R.drawable.ic_rearrange),
                 context.getResources().getString(R.string.rearrange_images)));
+
+        Drawable iconGrayscale = context.getResources().getDrawable(R.drawable.ic_photo_filter_black_24dp);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            iconGrayscale.setTint(Color.GRAY);
+        }
+        options.add(new EnhancementOptionsEntity(
+                iconGrayscale,
+                context.getResources().getString(R.string.grayscale_images)));
 
         //options.add(new EnhancementOptionsEntity(
         //      context.getResources().getDrawable(R.drawable.ic_branding_watermark_black_24dp),

--- a/app/src/main/java/swati4star/createpdf/util/ImageEnhancementOptionsUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageEnhancementOptionsUtils.java
@@ -55,9 +55,7 @@ public class ImageEnhancementOptionsUtils {
                 context.getResources().getString(R.string.rearrange_images)));
 
         Drawable iconGrayscale = context.getResources().getDrawable(R.drawable.ic_photo_filter_black_24dp);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            iconGrayscale.setTint(Color.GRAY);
-        }
+        iconGrayscale.setColorFilter(Color.GRAY, android.graphics.PorterDuff.Mode.SRC_IN);
         options.add(new EnhancementOptionsEntity(
                 iconGrayscale,
                 context.getResources().getString(R.string.grayscale_images)));

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,7 +10,7 @@
     <string name="open_pdf_text">Abrir PDF</string>
     <string name="create_pdf_text">Crear PDF</string>
     <string name="details"><b>Detalles</b></string>
-    <string name="search_hintr">Name of file</string>
+    <string name="search_hint">Name of file</string>
     <string name="search">search</string>
 
     <array name="items">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -72,7 +72,7 @@
     <string name="rate_us_text">"Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .     It converts images to PDF so smmothly. :) "</string>
     <string name="snackbar_no_share_app">No application to share.</string>
     <string name="extras">Extras</string>
-    <string name="share_chooserr">Select app to send message…</string>
+    <string name="share_chooser">Select app to send message…</string>
     <string name="feedback_chooser">Send mail…</string>
     <string name="no_pdf">No PDFs to show</string>
     <string name="get_started">Get Started Now</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -299,6 +299,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
-    <string name="grayscale_images">Create grayscale PDFs</string>
+    <string name="grayscale_images">Create grayscale PDF</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,7 +10,7 @@
     <string name="open_pdf_text">Abrir PDF</string>
     <string name="create_pdf_text">Crear PDF</string>
     <string name="details"><b>Detalles</b></string>
-    <string name="search_hint">Name of file</string>
+    <string name="search_hintr">Name of file</string>
     <string name="search">search</string>
 
     <array name="items">
@@ -72,7 +72,7 @@
     <string name="rate_us_text">"Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .     It converts images to PDF so smmothly. :) "</string>
     <string name="snackbar_no_share_app">No application to share.</string>
     <string name="extras">Extras</string>
-    <string name="share_chooser">Select app to send message…</string>
+    <string name="share_chooserr">Select app to send message…</string>
     <string name="feedback_chooser">Send mail…</string>
     <string name="no_pdf">No PDFs to show</string>
     <string name="get_started">Get Started Now</string>
@@ -299,5 +299,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
+    <string name="grayscale_images">Apply grayscale</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -64,7 +64,7 @@
     <string name="snackbar_pdfCreated">PDF created!</string>
     <string name="snackbar_viewAction">View</string>
     <string name="more_options_text">More Enhancement Options</string>
-    <string name="delete">borrar</string>
+    <string name="delete">Borrar</string>
     <string name="feedback_text">Kindly write your previous feeback, or just drop a Hi! :)</string>
     <string name="feedback_subject">Suggestions for Images To PDF Converter</string>
     <string name="snackbar_no_email_clients">There are no email clients installed.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -299,6 +299,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
-    <string name="grayscale_images">Apply grayscale</string>
+    <string name="grayscale_images">Create grayscale PDFs</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -299,6 +299,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
-    <string name="grayscale_images">Create grayscale PDFs</string>
+    <string name="grayscale_images">Create grayscale PDF</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="open_pdf_text">Ouvrir PDF</string>
     <string name="create_pdf_text">Créer PDF</string>
     <string name="details"><b>Détails</b></string>
-    <string name="search_hintr">Name of file</string>
+    <string name="search_hint">Name of file</string>
     <string name="search">search</string>
 
     <array name="items">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,7 +62,7 @@
     <string name="snackbar_pdfCreated">PDF created!</string>
     <string name="snackbar_viewAction">View</string>
     <string name="more_options_text">More Enhancement Options</string>
-    <string name="delete">effacer</string>
+    <string name="delete">Effacer</string>
     <string name="feedback_subject">Suggestions for Images To PDF Converter</string>
     <string name="feedback_text">Kindly write your previous feeback, or just drop a Hi! :)</string>
     <string name="snackbar_no_email_clients">There are no email clients installed.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="open_pdf_text">Ouvrir PDF</string>
     <string name="create_pdf_text">Créer PDF</string>
     <string name="details"><b>Détails</b></string>
-    <string name="search_hint">Name of file</string>
+    <string name="search_hintr">Name of file</string>
     <string name="search">search</string>
 
     <array name="items">
@@ -70,7 +70,7 @@
     <string name="rate_us_text">"Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .     It converts images to PDF so smmothly. :) "</string>
     <string name="snackbar_no_share_app">No application to share.</string>
     <string name="extras">Extras</string>
-    <string name="share_chooser">Select app to send message…</string>
+    <string name="share_chooserr">Select app to send message…</string>
     <string name="feedback_chooser">Send mail…</string>
     <string name="no_pdf">No PDFs to show</string>
     <string name="get_started">Get Started Now</string>
@@ -299,5 +299,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
+    <string name="grayscale_images">Apply grayscale</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -299,6 +299,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
-    <string name="grayscale_images">Apply grayscale</string>
+    <string name="grayscale_images">Create grayscale PDFs</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -70,7 +70,7 @@
     <string name="rate_us_text">"Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .     It converts images to PDF so smmothly. :) "</string>
     <string name="snackbar_no_share_app">No application to share.</string>
     <string name="extras">Extras</string>
-    <string name="share_chooserr">Select app to send message…</string>
+    <string name="share_chooser">Select app to send message…</string>
     <string name="feedback_chooser">Send mail…</string>
     <string name="no_pdf">No PDFs to show</string>
     <string name="get_started">Get Started Now</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -298,6 +298,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
-    <string name="grayscale_images">Create grayscale PDFs</string>
+    <string name="grayscale_images">Create grayscale PDF</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -8,7 +8,7 @@
     <string name="edit_images_text">Edit Images</string>
     <string name="open_pdf_text">Open PDF</string>
     <string name="create_pdf_text">Create PDF</string>
-    <string name="search_hintr">Name of file</string>
+    <string name="search_hint">Name of file</string>
     <string name="search">search</string>
 
     <string name="details"><b>詳細</b></string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,7 +63,7 @@
     <string name="snackbar_pdfCreated">PDF created!</string>
     <string name="snackbar_viewAction">View</string>
     <string name="more_options_text">More Enhancement Options</string>
-    <string name="delete">delete</string>
+    <string name="delete">Delete</string>
     <string name="feedback_text">Kindly write your previous feeback, or just drop a Hi! :)</string>
     <string name="feedback_subject">Suggestions for Images To PDF Converter</string>
     <string name="snackbar_no_email_clients">There are no email clients installed.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -71,7 +71,7 @@
     <string name="rate_us_text">"Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .     It converts images to PDF so smmothly. :) "</string>
     <string name="snackbar_no_share_app">No application to share.</string>
     <string name="extras">Extras</string>
-    <string name="share_chooserr">Select app to send message…</string>
+    <string name="share_chooser">Select app to send message…</string>
     <string name="feedback_chooser">Send mail…</string>
     <string name="no_pdf">No PDFs to show</string>
     <string name="get_started">Get Started Now</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -298,6 +298,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
-    <string name="grayscale_images">Apply grayscale</string>
+    <string name="grayscale_images">Create grayscale PDFs</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -8,7 +8,7 @@
     <string name="edit_images_text">Edit Images</string>
     <string name="open_pdf_text">Open PDF</string>
     <string name="create_pdf_text">Create PDF</string>
-    <string name="search_hint">Name of file</string>
+    <string name="search_hintr">Name of file</string>
     <string name="search">search</string>
 
     <string name="details"><b>詳細</b></string>
@@ -71,7 +71,7 @@
     <string name="rate_us_text">"Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .     It converts images to PDF so smmothly. :) "</string>
     <string name="snackbar_no_share_app">No application to share.</string>
     <string name="extras">Extras</string>
-    <string name="share_chooser">Select app to send message…</string>
+    <string name="share_chooserr">Select app to send message…</string>
     <string name="feedback_chooser">Send mail…</string>
     <string name="no_pdf">No PDFs to show</string>
     <string name="get_started">Get Started Now</string>
@@ -298,5 +298,6 @@
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
     <string name="home_page">Home</string>
+    <string name="grayscale_images">Apply grayscale</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,6 +379,6 @@
     <string name="viewfiles_rotatepages">1. Select the PDF you wish to rotate. \n2. Select Rotate Pages. \n3. Select angle of rotation. Select OK. \n4. New rotated PDF will be created.</string>
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
-    <string name="grayscale_images">Apply grayscale</string>
+    <string name="grayscale_images">Create grayscale PDFs</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="snackbar_pdfCreated">PDF created!</string>
     <string name="snackbar_viewAction">View</string>
     <string name="more_options_text">More Enhancement Options</string>
-    <string name="delete">delete</string>
+    <string name="delete">Delete</string>
 
     <!-- Share strings -->
     <string name="share_chooser">Select app to send message…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,6 +379,6 @@
     <string name="viewfiles_rotatepages">1. Select the PDF you wish to rotate. \n2. Select Rotate Pages. \n3. Select angle of rotation. Select OK. \n4. New rotated PDF will be created.</string>
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
-    <string name="grayscale_images">Create grayscale PDFs</string>
+    <string name="grayscale_images">Create grayscale PDF</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="open_pdf_text">Open PDF</string>
     <string name="create_pdf_text">Create PDF</string>
     <string name="details"><b>Details</b></string>
-    <string name="search_hint">Name of file</string>
+    <string name="search_hintr">Name of file</string>
     <string name="search">search</string>
     <string name="set_page_size_text">Set Page Size</string>
     <string name="preview_image_to_pdf">Preview PDF</string>
@@ -118,7 +118,7 @@
     <string name="delete">delete</string>
 
     <!-- Share strings -->
-    <string name="share_chooser">Select app to send message…</string>
+    <string name="share_chooserr">Select app to send message…</string>
 
     <!-- Rate us strings -->
     <string name="rate_us_text">Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .It converts images to PDF so smoothly. :)</string>
@@ -379,5 +379,6 @@
     <string name="viewfiles_rotatepages">1. Select the PDF you wish to rotate. \n2. Select Rotate Pages. \n3. Select angle of rotation. Select OK. \n4. New rotated PDF will be created.</string>
     <string name="viewfiles_addpassword">1. Select the PDF you wish to add password to. \n2. Select Add  Password. \n3. Type new password. Select OK. \n4. New PDF with password be created.</string>
     <string name="viewfiles_removepassword">1. Select the PDF you wish to remove password from. \n2. Select Remove Password. \n3. Type pdf password. Select OK. \n4. New PDF without PDF will be created.</string>
+    <string name="grayscale_images">Apply grayscale</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="open_pdf_text">Open PDF</string>
     <string name="create_pdf_text">Create PDF</string>
     <string name="details"><b>Details</b></string>
-    <string name="search_hintr">Name of file</string>
+    <string name="search_hint">Name of file</string>
     <string name="search">search</string>
     <string name="set_page_size_text">Set Page Size</string>
     <string name="preview_image_to_pdf">Preview PDF</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,7 @@
     <string name="delete">delete</string>
 
     <!-- Share strings -->
-    <string name="share_chooserr">Select app to send message…</string>
+    <string name="share_chooser">Select app to send message…</string>
 
     <!-- Rate us strings -->
     <string name="rate_us_text">Hi! I just checked this app in playstore. Try it out : https://play.google.com/store/apps/details?id=swati4star.createpdf .It converts images to PDF so smoothly. :)</string>


### PR DESCRIPTION
# Description

It's add grayscale filter for all images.
I did gray icon for it.
![image](https://user-images.githubusercontent.com/32689674/45952318-4df8e600-c00f-11e8-872a-6e57e41b12d1.png)
It's used picasso, because PhotoEditor needed PhotoEditorView.
Picasso transformation image, then used method createPdf().
![image](https://user-images.githubusercontent.com/32689674/45952473-cf507880-c00f-11e8-9028-205f923fa030.png)
It's worked :)

Fixes #138 Add an option to create grayscale PDF

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Manual testing.

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
