### PR TITLE
Fix crash when selected all items when there are no elements

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -181,14 +181,18 @@ public class ViewFilesFragment extends Fragment
                     showSnackbar(mActivity, R.string.snackbar_no_pdfs_selected);
                 break;
             case R.id.select_all:
-                if (mIsChecked) {
-                    mViewFilesAdapter.unCheckAll();
-                    mMenuItem.setIcon(R.drawable.ic_check_box_outline_blank_24dp);
+                if (mViewFilesAdapter.getItemCount() > 0) {
+                    if (mIsChecked) {
+                        mViewFilesAdapter.unCheckAll();
+                        mMenuItem.setIcon(R.drawable.ic_check_box_outline_blank_24dp);
+                    } else {
+                        mViewFilesAdapter.checkAll();
+                        mMenuItem.setIcon(R.drawable.ic_check_box_24dp);
+                    }
+                    mIsChecked = !mIsChecked;
                 } else {
-                    mViewFilesAdapter.checkAll();
-                    mMenuItem.setIcon(R.drawable.ic_check_box_24dp);
+                    showSnackbar(mActivity, R.string.snackbar_no_pdfs_selected);
                 }
-                mIsChecked = !mIsChecked;
                 break;
         }
         return true;


### PR DESCRIPTION
# Description

Fix crash app, when in ViewFiles there are no elements.
mFileList in VeiwFilesAdapter may be null.

Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
