### PR TITLE
Fix  [Issue #453] The current fragment is not getting highlighted when we select fragment from home page

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -309,4 +309,8 @@ public class MainActivity extends AppCompatActivity
         }
         return true;
     }
+
+    public void setNavigationViewSelection(int index) {
+        mNavigationView.getMenu().getItem(index).setChecked(true);
+    }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import swati4star.createpdf.R;
+import swati4star.createpdf.activity.MainActivity;
 import swati4star.createpdf.customviews.MyCardView;
 
 import static swati4star.createpdf.util.Constants.BUNDLE_DATA;
@@ -83,6 +84,11 @@ public class HomeFragment extends Fragment implements View.OnClickListener {
         mActivity = (Activity) context;
     }
 
+    private void setNavigationViewSelection(int index) {
+        if (mActivity instanceof MainActivity)
+            ((MainActivity) mActivity).setNavigationViewSelection(index);
+    }
+
     @Override
     public void onClick(View v) {
 
@@ -93,57 +99,71 @@ public class HomeFragment extends Fragment implements View.OnClickListener {
         switch (v.getId()) {
             case R.id.images_to_pdf:
                 fragment = new ImageToPdfFragment();
+                setNavigationViewSelection(1);
                 break;
             case R.id.qr_barcode_to_pdf:
                 fragment = new QrBarcodeScanFragment();
+                setNavigationViewSelection(2);
                 break;
             case R.id.text_to_pdf:
                 fragment = new TextToPdfFragment();
+                setNavigationViewSelection(6);
                 break;
             case R.id.view_files:
                 fragment = new ViewFilesFragment();
+                setNavigationViewSelection(3);
                 break;
             case R.id.view_history:
                 fragment = new HistoryFragment();
+                setNavigationViewSelection(11);
                 break;
             case R.id.merge_pdf:
                 fragment = new MergeFilesFragment();
+                setNavigationViewSelection(4);
                 break;
             case R.id.split_pdf:
                 fragment = new SplitFilesFragment();
+                setNavigationViewSelection(5);
                 break;
             case R.id.compress_pdf:
                 fragment = new RemovePagesFragment();
                 bundle.putString(BUNDLE_DATA, COMPRESS_PDF);
                 fragment.setArguments(bundle);
+                setNavigationViewSelection(7);
                 break;
             case R.id.extract_images:
                 fragment = new ExtractImagesFragment();
+                setNavigationViewSelection(10);
                 break;
             case R.id.remove_pages:
                 fragment = new RemovePagesFragment();
                 bundle.putString(BUNDLE_DATA, REMOVE_PAGES);
                 fragment.setArguments(bundle);
+                setNavigationViewSelection(8);
                 break;
             case R.id.rearrange_pages:
                 fragment = new RemovePagesFragment();
                 bundle.putString(BUNDLE_DATA, REORDER_PAGES);
                 fragment.setArguments(bundle);
+                setNavigationViewSelection(9);
                 break;
             case R.id.add_password:
                 fragment = new ViewFilesFragment();
                 bundle.putInt(BUNDLE_DATA, ADD_PASSWORD);
                 fragment.setArguments(bundle);
+                setNavigationViewSelection(3);
                 break;
             case R.id.remove_password:
                 fragment = new ViewFilesFragment();
                 bundle.putInt(BUNDLE_DATA, REMOVE_PASSWORD);
                 fragment.setArguments(bundle);
+                setNavigationViewSelection(3);
                 break;
             case R.id.rotate_pages:
                 fragment = new ViewFilesFragment();
                 bundle.putInt(BUNDLE_DATA, ROTATE_PAGES);
                 fragment.setArguments(bundle);
+                setNavigationViewSelection(3);
                 break;
         }
 


### PR DESCRIPTION
Fix  [Issue #453] The current fragment is not getting highlighted when we select fragment from home page

# Description

Add public method in MainActivity to select navigation menu item and call it from home fragment

Fixes #453 
* added public method to select navigation menu item
* added call of method in home fragment

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
