### PR TITLE
[Fixes #460] Added animation to bottom sheet arrow icon when it slides or is hidden

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/ExtractImagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ExtractImagesFragment.java
@@ -83,7 +83,7 @@ public class ExtractImagesFragment extends Fragment implements MergeFilesAdapter
         View rootview = inflater.inflate(R.layout.fragment_extract_images, container, false);
         ButterKnife.bind(this, rootview);
         sheetBehavior = BottomSheetBehavior.from(layoutBottomSheet);
-        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, mDownArrow));
+        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, isAdded()));
         mBottomSheetUtils.populateBottomSheetWithPDFs(mLayout,
                 mRecyclerViewFiles, this);
         resetView();

--- a/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
@@ -119,7 +119,7 @@ public class MergeFilesFragment extends Fragment implements MergeFilesAdapter.On
         mSelectedFiles.setAdapter(mMergeSelectedFilesAdapter);
         mSelectedFiles.addItemDecoration(new ViewFilesDividerItemDecoration(mActivity));
 
-        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, mDownArrow));
+        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, isAdded()));
         setMorphingButtonState(false);
 
         return root;

--- a/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
@@ -98,7 +98,7 @@ public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.O
         View rootview = inflater.inflate(R.layout.fragment_remove_pages, container, false);
         ButterKnife.bind(this, rootview);
         sheetBehavior = BottomSheetBehavior.from(layoutBottomSheet);
-        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, mDownArrow));
+        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, isAdded()));
         mOperation = getArguments().getString(BUNDLE_DATA);
         mBottomSheetUtils.populateBottomSheetWithPDFs(mLayout,
                 mRecyclerViewFiles, this);

--- a/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
@@ -75,7 +75,7 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
         View rootview = inflater.inflate(R.layout.fragment_split_files, container, false);
         ButterKnife.bind(this, rootview);
         sheetBehavior = BottomSheetBehavior.from(layoutBottomSheet);
-        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, mDownArrow));
+        sheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, isAdded()));
         mBottomSheetUtils.populateBottomSheetWithPDFs(mLayout,
                 mRecyclerViewFiles, this);
         resetValues();

--- a/app/src/main/java/swati4star/createpdf/util/BottomSheetCallback.java
+++ b/app/src/main/java/swati4star/createpdf/util/BottomSheetCallback.java
@@ -9,28 +9,35 @@ import android.widget.ImageView;
 public class BottomSheetCallback extends BottomSheetBehavior.BottomSheetCallback {
 
     private ImageView mUpArrow;
-    private ImageView mDownArrow;
+    private boolean mIsAdded;
 
-    public BottomSheetCallback(ImageView mUpArrow, ImageView mDownArrow) {
-        this.mDownArrow = mDownArrow;
+    public BottomSheetCallback(ImageView mUpArrow, boolean mIsFragmentAdded) {
         this.mUpArrow = mUpArrow;
+        this.mIsAdded = mIsFragmentAdded;
     }
 
     @Override
     public void onStateChanged(@NonNull View bottomSheet, int newState) {
-        switch (newState) {
-            case BottomSheetBehavior.STATE_EXPANDED:
-                mUpArrow.setVisibility(View.GONE);
-                mDownArrow.setVisibility(View.VISIBLE);
-                break;
-            case BottomSheetBehavior.STATE_COLLAPSED:
-                mUpArrow.setVisibility(View.VISIBLE);
-                mDownArrow.setVisibility(View.GONE);
-                break;
-        }
     }
 
     @Override
     public void onSlide(@NonNull View bottomSheet, float slideOffset) {
+        //ensure the fragment is currently added to its activity
+        if (mIsAdded) {
+            animateBottomSheetArrow(slideOffset);
+        }
+    }
+
+    /**
+     * animates the upArrow icon when sliding the bottom sheet
+     *
+     * @param slideOffset offset to use to sync the animation with bottom sheet sliding
+     */
+    private void animateBottomSheetArrow(float slideOffset) {
+        if (slideOffset >= 0 && slideOffset <= 1) {
+            mUpArrow.setRotation(slideOffset * -180);
+        } else if (slideOffset >= -1 && slideOffset < 0) {
+            mUpArrow.setRotation(slideOffset * 180);
+        }
     }
 }


### PR DESCRIPTION
# Description

Animation added to the bottom sheet arrow icon as per the [reference article](https://android.jlelse.eu/choreographic-animations-with-androids-bottomsheet-fef06e6ecb81). The icon animates when expanded or collapsed and when being hidden out of sight in the fragment.

Changes made in `BottomSheetCallback.java`. The constructor has been updated - the bottom sheet now uses only a single icon, instead of swtiching visibility between two icons and takes an additional boolean flag that checks whether the fragment has been added to the activity or not before performing the animation.

![ezgif com-resize](https://user-images.githubusercontent.com/5392993/46570678-a8863080-c985-11e8-83b2-feed45a0d363.gif)

Fixes #(460)

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
