### PR TITLE
Remove pages allows with external storage

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
@@ -134,7 +134,7 @@ public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.O
             Log.v("output", pages + " ");
             String outputPath = mPath.replace(mActivity.getString(R.string.pdf_ext),
                     "_edited" + pages + mActivity.getString(R.string.pdf_ext));
-            if (mPDFUtils.isPDFEncrypted(mUri)) {
+            if (mPDFUtils.isPDFEncrypted(mPath)) {
                 showSnackbar(mActivity, R.string.encrypted_pdf);
                 return;
             }

--- a/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
@@ -1,10 +1,12 @@
 package swati4star.createpdf.fragment;
 
 import android.app.Activity;
+import android.content.ContentProvider;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.pdf.PdfRenderer;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
 import android.support.annotation.NonNull;
@@ -91,6 +93,7 @@ public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.O
     TextView mInfoText;
     @BindView(R.id.compressionInfoText)
     TextView mCompressionInfoText;
+    private Uri mUri;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -123,14 +126,15 @@ public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.O
     public void onActivityResult(int requestCode, int resultCode, Intent data) throws NullPointerException {
         if (data == null || resultCode != RESULT_OK )
             return;
-        if (requestCode == INTENT_REQUEST_PICKFILE_CODE)
+        if (requestCode == INTENT_REQUEST_PICKFILE_CODE) {
+            mUri = data.getData();
             setTextAndActivateButtons(getFilePath(data.getData()));
-        else if (requestCode == INTENT_REQUEST_REARRANGE_PDF) {
+        } else if (requestCode == INTENT_REQUEST_REARRANGE_PDF) {
             String pages = data.getStringExtra(RESULT);
             Log.v("output", pages + " ");
             String outputPath = mPath.replace(mActivity.getString(R.string.pdf_ext),
                     "_edited" + pages + mActivity.getString(R.string.pdf_ext));
-            if (mPDFUtils.isPDFEncrypted(mPath)) {
+            if (mPDFUtils.isPDFEncrypted(mUri)) {
                 showSnackbar(mActivity, R.string.encrypted_pdf);
                 return;
             }
@@ -152,7 +156,7 @@ public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.O
         ArrayList<Bitmap> bitmaps = new ArrayList<>();
         ParcelFileDescriptor fileDescriptor = null;
         try {
-            fileDescriptor = ParcelFileDescriptor.open(new File(mPath), MODE_READ_ONLY);
+            fileDescriptor = getContext().getContentResolver().openFileDescriptor(mUri, "r");
             PdfRenderer renderer = new PdfRenderer(fileDescriptor);
             final int pageCount = renderer.getPageCount();
             for (int i = 0; i < pageCount; i++) {


### PR DESCRIPTION
# Description

I fixed the bug where Remove Pages would not work with files stored in external storage. Did this by using the appropriate method to get the ParcelFileDescriptor.
I noticed that the project relies on passing the file path as a `String`instead of using `Uri`, being the last more reliable in order to avoid problems accessing files.

Fixes #444 	

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
