### PR TITLE
[WIP] - Fix for issue #346

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
@@ -298,22 +298,24 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
     public void onItemClick(View view, int position) {
         //setting mClicked true when none filter is selected otherwise false
         mClicked = position == 0;
-        // Brush effect is in second position
+        //Brush effect is in second position
         if (position == 1) {
             mPhotoEditor = new PhotoEditor.Builder(this, mPhotoEditorView)
                     .setPinchTextScalable(true)
                     .build();
 
             Log.i("Brush Effect", "Brush Effect Selected!");
-            mPhotoEditorView.setOnTouchListener(new View.OnTouchListener() {
+            //mPhotoEditorView.setOnTouchListener(new View.OnTouchListener() {
+            mPhotoScrollView.setOnTouchListener(new View.OnTouchListener() {
                 @Override
                 public boolean onTouch(View v, MotionEvent event) {
                     Log.i("PhotoEditorView", "PhotoEditorView has been onTouched");
-                    v.getParent().requestDisallowInterceptTouchEvent(true);
-                    return false;
+                    //v.getParent().requestDisallowInterceptTouchEvent(true);
+                    //return false;
+                    return true;
                 }
             });
-
+            
             if (doodleSeekBar.getVisibility() == View.GONE && brushColorsView.getVisibility() == View.GONE) {
                 showBrushEffect();
             } else if (doodleSeekBar.getVisibility() == View.VISIBLE &&

--- a/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
@@ -10,8 +10,11 @@ import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageButton;
+import android.widget.ScrollView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -61,6 +64,8 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
     SeekBar doodleSeekBar;
     @BindView(R.id.photoEditorView)
     PhotoEditorView mPhotoEditorView;
+    @BindView(R.id.scrollViewImage)
+    ScrollView mPhotoScrollView;
     @BindView(R.id.doodle_colors)
     RecyclerView brushColorsView;
 
@@ -298,6 +303,17 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
             mPhotoEditor = new PhotoEditor.Builder(this, mPhotoEditorView)
                     .setPinchTextScalable(true)
                     .build();
+
+            Log.i("Brush Effect", "Brush Effect Selected!");
+            mPhotoEditorView.setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent event) {
+                    Log.i("PhotoEditorView", "PhotoEditorView has been onTouched");
+                    v.getParent().requestDisallowInterceptTouchEvent(true);
+                    return false;
+                }
+            });
+
             if (doodleSeekBar.getVisibility() == View.GONE && brushColorsView.getVisibility() == View.GONE) {
                 showBrushEffect();
             } else if (doodleSeekBar.getVisibility() == View.VISIBLE &&


### PR DESCRIPTION
# Description

The purpose of this fix is to disable the vertical scrolling when the Brush Effect is selected on "Filter Images." I am able to disable the vertical scrolling entirely but vertical edits are still not detected properly by `mPhotoEditor.` 

Specifically, I can disable the scroll completely on the `ScrollView` that is the parent for `mPhotoEditorView`. I'm not entirely familiar with the codebase yet, however, once the `mPhotoEditor` is instantiated it seems that the `PhotoEditorView` does not detect touches anymore as it's handled by the `PhotoEditor` object `mPhotoEditor.` 

In essence, I'm not sure where to proceed from here as PhotoEditor.java is Read-Only, and from the debug Log statements I put in, it seems that I can't set the `requestDisallowInterceptTouchEvent()` properly to ignore scrolling in the parent `ScrollView` since `mPhotoEditorView` is not detecting any touches at all (It seems to be handled by `mPhotoEditor` after it is built on line 303 in ImageEditor.java.
 
---**WORK IN PROGRESS**--- Fix for #346 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
