### PR TITLE
Issue #502. Use Image cropper in own custom activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
             <meta-data android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+        <activity
+            android:name=".activity.CropImageActivity"/>
 
         <provider
             android:name="android.support.v4.content.FileProvider"

--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -1,0 +1,131 @@
+package swati4star.createpdf.activity;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.theartofdev.edmodo.cropper.CropImage;
+import com.theartofdev.edmodo.cropper.CropImageView;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import swati4star.createpdf.R;
+import swati4star.createpdf.fragment.ImageToPdfFragment;
+import swati4star.createpdf.util.FileUtils;
+
+import static swati4star.createpdf.util.Constants.pdfDirectory;
+
+public class CropImageActivity extends AppCompatActivity {
+
+    private int mCurrentImageIndex = 0;
+    private ArrayList<String> mImages;
+    private HashMap<Integer, Uri> mCroppedImageUris = new HashMap<Integer, Uri>();
+
+    private TextView mImagecount;
+    private CropImageView mCropImageView;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_crop_image_activity);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        getSupportActionBar().setHomeButtonEnabled(true);
+
+        setUpCropImageView();
+
+        Button cropImageButton = findViewById(R.id.cropButton);
+        cropImageButton.setOnClickListener((View v) -> {
+            String root = Environment.getExternalStorageDirectory().toString();
+            File myDir = new File(root + pdfDirectory);
+            String fname = "cropped_" + FileUtils.getFileName(mCropImageView.getImageUri().getPath());
+
+            File file = new File(myDir, fname);
+
+            mCropImageView.saveCroppedImageAsync(Uri.fromFile(file));
+        });
+
+        Button rotateButton = findViewById(R.id.rotateButton);
+        rotateButton.setOnClickListener((View v) -> {
+            mCropImageView.rotateImage(90);
+        });
+
+        mImagecount = findViewById(R.id.imagecount);
+
+        ImageView nextimageButton = findViewById(R.id.nextimageButton);
+        nextimageButton.setOnClickListener((View v) -> {
+            if (mCurrentImageIndex == mImages.size() - 1) {
+                setImage(0);
+            } else {
+                setImage(mCurrentImageIndex + 1);
+            }
+        });
+
+        mImages = ImageToPdfFragment.mImagesUri;
+
+        setImage(0);
+
+        /*  .setActivityMenuIconColor(mMorphButtonUtility.color(R.color.colorPrimary))
+                .setInitialCropWindowPaddingRatio(0)
+                .setAllowRotation(true)
+                .setActivityTitle(getString(R.string.cropImage_activityTitle) + (mImageCounter + 1))
+                .start(mActivity, this);*/
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.activity_crop_image, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            // Respond to the action bar's Up/Home button
+            case android.R.id.home:
+                setResult(Activity.RESULT_CANCELED);
+                finish();
+                return true;
+            case R.id.action_done:
+                Intent intent = new Intent();
+                intent.putExtra(CropImage.CROP_IMAGE_EXTRA_RESULT, mCroppedImageUris);
+                setResult(Activity.RESULT_OK, intent);
+                finish();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void setUpCropImageView() {
+        mCropImageView = findViewById(R.id.cropImageView);
+        mCropImageView.setOnCropImageCompleteListener((CropImageView view, CropImageView.CropResult result) -> {
+            mCroppedImageUris.put(mCurrentImageIndex, result.getUri());
+            Toast.makeText(CropImageActivity.this, R.string.image_successfully_cropped, Toast.LENGTH_SHORT).show();
+        });
+    }
+
+    private void setImage(int index) {
+        mImagecount.setText(getString(R.string.cropImage_activityTitle) + (index + 1));
+
+        mCurrentImageIndex = index;
+        mCropImageView.setImageUriAsync(Uri.fromFile(new File(mImages.get(index))));
+    }
+}

--- a/app/src/main/res/layout/activity_crop_image_activity.xml
+++ b/app/src/main/res/layout/activity_crop_image_activity.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context=".activity.MainActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?android:attr/actionBarSize"
+            android:theme="@style/ToolbarTheme"
+            app:titleTextColor="?attr/titleToolbarTextColor" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context=".activity.CropImageActivity">
+
+        <com.theartofdev.edmodo.cropper.CropImageView
+            android:id="@+id/cropImageView"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/cropButton"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="5dp"
+                android:background="@drawable/cornered_edges"
+                android:text="@string/crop"
+                android:textAllCaps="false"
+                android:textColor="?attr/bottomSheetTextColor" />
+
+            <Button
+                android:id="@+id/rotateButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:background="@drawable/cornered_edges"
+                android:paddingEnd="5dp"
+                android:paddingStart="5dp"
+                android:text="@string/rotate"
+                android:textAllCaps="false"
+                android:textColor="?attr/bottomSheetTextColor" />
+
+            <ImageView
+                android:id="@+id/previousImageButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="5dp"
+                android:contentDescription="@string/previous_image_content_desc"
+                android:gravity="center"
+                android:tint="?attr/bottomSheetColor"
+                android:visibility="invisible"
+                app:srcCompat="@drawable/ic_navigate_before_white_24dp"
+                tools:targetApi="lollipop" />
+
+            <TextView
+                android:id="@+id/imagecount"
+                android:layout_width="150dp"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:text="@string/showing_image" />
+
+            <ImageView
+                android:id="@+id/nextimageButton"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:contentDescription="@string/nextimage_contentdesc"
+                android:gravity="center"
+                android:tint="?attr/bottomSheetColor"
+                app:srcCompat="@drawable/ic_navigate_next_black_24dp"
+                tools:targetApi="lollipop" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/activity_crop_image.xml
+++ b/app/src/main/res/menu/activity_crop_image.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_done"
+        android:title="@string/done"
+        app:showAsAction="always"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,6 +313,10 @@
     <string name="image_rearranging_options">Image Rearranging Options</string>
     <string name="filter_file_name">%s_%s.jpg</string>
     <string name="reset">Reset</string>
+    <string name="crop">Crop</string>
+    <string name="rotate">Rotate</string>
+    <string name="done">Done</string>
+    <string name="image_successfully_cropped">Image successfully cropped</string>
 
     <string name="confirm_exit_message">Press back again to exit</string>
 


### PR DESCRIPTION
# Description
Image cropper will now be used in it's own custom activity. String variables added in the change will need to be translated.

<img width="314" alt="screen shot 2018-10-14 at 8 22 19 pm" src="https://user-images.githubusercontent.com/2296196/46928333-ea028580-cfee-11e8-80cc-fc7683e2d8b7.png">

Fixes #502

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease` // Note: is broken due to missing translations
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
