### PR TITLE
Add a previous button in image cropper activity (#507)

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -88,6 +88,16 @@ public class CropImageActivity extends AppCompatActivity {
         }
     }
 
+    @OnClick(R.id.previousImageButton)
+    public void prevImgBtnClicked() {
+        if (mCurrentImageIndex == 0) {
+
+            setImage(mImages.size() - 1);
+        } else {
+            setImage(mCurrentImageIndex - 1);
+        }
+    }
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);

--- a/app/src/main/res/layout/activity_crop_image_activity.xml
+++ b/app/src/main/res/layout/activity_crop_image_activity.xml
@@ -68,7 +68,6 @@
                 android:contentDescription="@string/previous_image_content_desc"
                 android:gravity="center"
                 android:tint="?attr/bottomSheetColor"
-                android:visibility="invisible"
                 app:srcCompat="@drawable/ic_navigate_before_white_24dp"
                 tools:targetApi="lollipop" />
 


### PR DESCRIPTION
# Description

This commit makes visible previous button visible in ImageCropperActivity and implements required functionality.

Fixes #507

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
