### PR TITLE
PDF from camera image, closes #510

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java
@@ -44,7 +44,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -253,7 +252,6 @@ public class ImageToPdfFragment extends Fragment implements OnItemClickListner,
     }
 
 
-
     /**
      * Called after user is asked to grant permissions
      *
@@ -298,12 +296,10 @@ public class ImageToPdfFragment extends Fragment implements OnItemClickListner,
         switch (requestCode) {
             case INTENT_REQUEST_GET_IMAGES:
                 mImagesUri.clear();
-                List<Uri> imageUris = Matisse.obtainResult(data);
-                for (Uri uri : imageUris)
-                    mImagesUri.add(mFileUtils.getUriRealPath(uri));
-                if (imageUris.size() > 0) {
+                mImagesUri.addAll(Matisse.obtainPathResult(data));
+                if (mImagesUri.size() > 0) {
                     mNoOfImages.setText(String.format(mActivity.getResources()
-                            .getString(R.string.images_selected), imageUris.size()));
+                            .getString(R.string.images_selected), mImagesUri.size()));
                     mNoOfImages.setVisibility(View.VISIBLE);
                     showSnackbar(mActivity, R.string.snackbar_images_added);
                     mCreatePdf.setEnabled(true);
@@ -318,7 +314,7 @@ public class ImageToPdfFragment extends Fragment implements OnItemClickListner,
                 HashMap<Integer, Uri> croppedImageUris =
                         (HashMap) data.getSerializableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT);
 
-                for (int i = 0; i < mImagesUri.size(); i++)  {
+                for (int i = 0; i < mImagesUri.size(); i++) {
                     if (croppedImageUris.get(i) != null) {
                         mImagesUri.set(i, croppedImageUris.get(i).getPath());
                         showSnackbar(mActivity, R.string.snackbar_imagecropped);


### PR DESCRIPTION
# Description

On line 301 of [ImageToPdfFragment.java](https://github.com/Swati4star/Images-to-PDF/blob/399b67765abfe2c943239ea263ee3479435ea432/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java#L301), `Matisse.obtainResult(data)` gives a list of `Uri`. But running a Content Resolver query to get the file path returns an empty cursor because the newly clicked image is not added to the MediaStore database. Hence, an empty string is set as source for the PDF creator and a null/invalid PDF is generated.

Luckily, `Matisse` has another method `obtainPathResult(data)`, which gives a list of `String` containing the absoluted path of the image, which is set as the source and the resulting PDF is not invalid.

Fixes #510

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
