### PR TITLE
#431 fix issue, chceckbox added before each file

### DIFF
--- a/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
@@ -2,6 +2,7 @@ package swati4star.createpdf.adapter;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.AppCompatCheckBox;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import butterknife.OnClick;
 import swati4star.createpdf.R;
 import swati4star.createpdf.util.FileUtils;
 import swati4star.createpdf.util.PDFUtils;
@@ -58,6 +60,8 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
         TextView mFileName;
         @BindView(R.id.encryptionImage)
         ImageView mEncryptionImage;
+        @BindView(R.id.itemMerge_checkbox)
+        AppCompatCheckBox mCheckbox;
 
         ViewMergeFilesHolder(View itemView) {
             super(itemView);
@@ -67,8 +71,15 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
 
         @Override
         public void onClick(View view) {
+            mCheckbox.toggle();
             mOnClickListener.onItemClick(mFilePaths.get(getAdapterPosition()));
         }
+
+        @OnClick(R.id.itemMerge_checkbox)
+        public void onCheckboxClick() {
+            mOnClickListener.onItemClick(mFilePaths.get(getAdapterPosition()));
+        }
+
     }
 
     public interface OnClickListener {

--- a/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
@@ -292,11 +292,20 @@ public class MergeFilesFragment extends Fragment implements MergeFilesAdapter.On
 
     @Override
     public void onItemClick(String path) {
-        mFilePaths.add(path);
+        if (mFilePaths.contains(path)) {
+            mFilePaths.remove(path);
+            showSnackbar(mActivity, getString(R.string.pdf_removed_from_list));
+        } else {
+            mFilePaths.add(path);
+            showSnackbar(mActivity, getString(R.string.pdf_added_to_list));
+        }
+
         mMergeSelectedFilesAdapter.notifyDataSetChanged();
-        if (mFilePaths.size() > 1 && !mergeBtn.isEnabled())
-            setMorphingButtonState(true);
-        showSnackbar(mActivity, getString(R.string.pdf_added_to_list));
+        if (mFilePaths.size() > 1) {
+            if (!mergeBtn.isEnabled()) setMorphingButtonState(true);
+        } else {
+            if (mergeBtn.isEnabled()) setMorphingButtonState(false);
+        }
     }
 
     /**

--- a/app/src/main/res/layout/item_merge_files.xml
+++ b/app/src/main/res/layout/item_merge_files.xml
@@ -4,15 +4,25 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <android.support.v7.widget.AppCompatCheckBox
+        android:id="@+id/itemMerge_checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_centerVertical="true"/>
+
     <com.balysv.materialripple.MaterialRippleLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true">
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="8dp"
+        android:layout_toEndOf="@id/itemMerge_checkbox">
 
         <TextView
             android:id="@+id/fileName"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:padding="12dp"
             android:textSize="16sp"
             android:textStyle="bold" />


### PR DESCRIPTION
# Description

In merge PDF, users can select multiple files to be merged. CheckBoxes are added and work corectly:
On checking files be added for merge.
On unchecking, remove it.

![45405001_487033438473856_8112866723025125376_n](https://user-images.githubusercontent.com/43934872/47953554-8fba6c00-df7f-11e8-9ce6-70c6ac3e757e.png)
![45182209_276279686335616_8375477692270641152_n](https://user-images.githubusercontent.com/43934872/47953555-91842f80-df7f-11e8-8942-8c85293fc363.png)


Fixes #431 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
