### PR TITLE
Add possibility to create pdf file also from .doc and .docx files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,13 @@ dependencies {
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.airbnb.android:lottie:2.5.5'
 
+    // libraries for reading from doc and docx files
+    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '2.4.0'
+    implementation group: 'org.apache.poi', name: 'poi', version: '3.9'
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '3.9'
+    implementation group: 'org.apache.poi', name: 'poi-ooxml-schemas', version: '3.9'
+    implementation group: 'org.apache.poi', name: 'poi-scratchpad', version: '3.9'
+
     // Itext pdf library
     implementation 'com.itextpdf:itextg:5.5.10'
     implementation 'com.madgag.spongycastle:core:1.58.0.0'

--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -89,6 +89,14 @@ public class MainActivity extends AppCompatActivity
         // initialize values
         initializeValues();
 
+        // suitable xml parsers for reading .docx files
+        System.setProperty("org.apache.poi.javax.xml.stream.XMLInputFactory",
+                "com.fasterxml.aalto.stax.InputFactoryImpl");
+        System.setProperty("org.apache.poi.javax.xml.stream.XMLOutputFactory",
+                "com.fasterxml.aalto.stax.OutputFactoryImpl");
+        System.setProperty("org.apache.poi.javax.xml.stream.XMLEventFactory",
+                "com.fasterxml.aalto.stax.EventFactoryImpl");
+
         // Check for app shortcuts & select default fragment
         Fragment fragment = checkForAppShortcutClicked();
 

--- a/app/src/main/java/swati4star/createpdf/fragment/QrBarcodeScanFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/QrBarcodeScanFragment.java
@@ -172,7 +172,6 @@ public class QrBarcodeScanFragment extends Fragment implements View.OnClickListe
                 .show();
     }
 
-
     /**
      * function to create PDF
      *
@@ -187,7 +186,7 @@ public class QrBarcodeScanFragment extends Fragment implements View.OnClickListe
             PDFUtils fileUtil = new PDFUtils(mActivity);
             int fontSize = mSharedPreferences.getInt(Constants.DEFAULT_FONT_SIZE_TEXT, Constants.DEFAULT_FONT_SIZE);
             fileUtil.createPdf(new TextToPDFOptions(mFilename, PageSizeUtils.mPageSize, false,
-                    "", uri, fontSize, mFontFamily));
+                    "", uri, fontSize, mFontFamily), Constants.textExtension);
             final String finalMPath = mPath;
             getSnackbarwithAction(mActivity, R.string.snackbar_pdfCreated)
                     .setAction(R.string.snackbar_viewAction, v -> mFileUtils.openFile(finalMPath)).show();

--- a/app/src/main/java/swati4star/createpdf/fragment/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/TextToPdfFragment.java
@@ -25,6 +25,7 @@ import android.widget.EditText;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -67,6 +68,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner {
     private final int mFileSelectCode = 0;
     private Uri mTextFileUri = null;
     private String mFontTitle;
+    private String mFileExtension;
     private int mFontSize = 0;
     private int mButtonClicked = 0;
     private boolean mPasswordProtected = false;
@@ -315,7 +317,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner {
             PDFUtils fileUtil = new PDFUtils(mActivity);
             mFontSize = mSharedPreferences.getInt(Constants.DEFAULT_FONT_SIZE_TEXT, Constants.DEFAULT_FONT_SIZE);
             fileUtil.createPdf(new TextToPDFOptions(mFilename, PageSizeUtils.mPageSize, mPasswordProtected,
-                    mPassword, mTextFileUri, mFontSize, mFontFamily));
+                    mPassword, mTextFileUri, mFontSize, mFontFamily), mFileExtension);
             final String finalMPath = mPath;
             getSnackbarwithAction(mActivity, R.string.snackbar_pdfCreated)
                     .setAction(R.string.snackbar_viewAction, v -> mFileUtils.openFile(finalMPath)).show();
@@ -336,7 +338,11 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner {
     public void selectTextFile() {
         if (mButtonClicked == 0) {
             Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-            intent.setType(getString(R.string.text_type));
+//            intent.setType(getString(R.string.text_type));
+            intent.setType("*/*");
+            String[] mimetypes = {"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "application/msword", getString(R.string.text_type)};
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, mimetypes);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
             try {
                 startActivityForResult(
@@ -358,6 +364,11 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner {
                     mTextFileUri = data.getData();
                     showSnackbar(mActivity, R.string.text_file_selected);
                     String fileName = mFileUtils.getFileName(mTextFileUri);
+                    if (fileName != null) {
+                        if (fileName.endsWith(Constants.textExtension)) mFileExtension = Constants.textExtension;
+                        else if (fileName.endsWith(Constants.docxExtension)) mFileExtension = Constants.docxExtension;
+                        else if (fileName.endsWith(Constants.docExtension)) mFileExtension = Constants.docExtension;
+                    }
                     fileName = getString(R.string.text_file_name) + fileName;
                     mTextView.setText(fileName);
                     mTextView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/swati4star/createpdf/util/Constants.java
+++ b/app/src/main/java/swati4star/createpdf/util/Constants.java
@@ -43,6 +43,9 @@ public class Constants {
     public static final String pdfExtension = ".pdf";
     public static final String appName = "PDF Converter";
     public static final String PATH_SEPERATOR = "/";
+    public static final String textExtension = ".txt";
+    public static final String docExtension = ".doc";
+    public static final String docxExtension = ".docx";
 
     public static final String AUTHORITY_APP = "com.swati4star.shareFile";
 


### PR DESCRIPTION
# Description
I added possibility to allow user pick also .doc and .docx files from TextToPdfFragment. Following this I added 2 new methods for reading .doc and .docx files. In order to be able read .doc and .docx files I have to added several libraries (check build.gradle). Using these libraries .doc and .docx files could be read as String.

Fixes #248 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
