### PR TITLE
fix #557 : remove overlapping of date and type textviews

### DIFF
--- a/app/src/main/res/layout/layout_item_history.xml
+++ b/app/src/main/res/layout/layout_item_history.xml
@@ -48,7 +48,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="0dp"
                 android:layout_weight="1"
-                android:padding="8dp"
+                android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:paddingTop="8dp"
                 android:textSize="12sp" />
 
             <TextView


### PR DESCRIPTION
# Description

Fixed the overlapping of date and type in history section.
![photo6271423366749595739](https://user-images.githubusercontent.com/31244999/52574061-760fa700-2e41-11e9-9055-1017e7d3b880.jpg)


Fixes #557 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
