### PR TITLE
Fix Titlebarcount problem

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -345,6 +345,15 @@ public class ViewFilesFragment extends Fragment
     }
 
     @Override
+    public void onStop() {
+        super.onStop();
+        AppCompatActivity activity = ((AppCompatActivity)
+                Objects.requireNonNull(mActivity));
+        ActionBar actionBar = activity.getSupportActionBar();
+        actionBar.setTitle(appName);
+    }
+
+    @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);


### PR DESCRIPTION
# Description
It fixes the issue of showing the number count on the title bar when viewed and selected files. This now shows appname on going back or any other section.

Fixes #571 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
