### PR TITLE
Fixed icon issue, both invert pdf options have the same icon now

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -72,7 +72,7 @@
                     android:title="@string/compress_pdf"/>
                 <item
                     android:id="@+id/nav_invert_pdf"
-                    android:icon="@drawable/ic_remove_circle_black_24dp"
+                    android:icon="@drawable/ic_invert_color_24dp"
                     android:title="@string/invert_pdf" />
 
             </menu>


### PR DESCRIPTION
# Description

Just changed the logo in the navigation menu to the appropriate invert pdf logo found in the menu.

Fixes #586 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
