### PR TITLE
[Fixes #537] fix bug with check/uncheck files in ViewFiles fragment

### DIFF
--- a/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
@@ -235,11 +235,6 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
         return position;
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
     /**
      * Sets pdf files
      *

--- a/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -190,6 +192,23 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
     public void unCheckAll() {
         mSelectedFiles.clear();
         notifyDataSetChanged();
+        updateActionBarTitle();
+    }
+
+    /**
+     * Sets the action bar title to app name when all files have been unchecked
+     */
+    private void updateActionBarTitle() {
+        ActionBar actionBar = ((AppCompatActivity) mActivity).getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setTitle(R.string.app_name);
+        }
+    }
+
+    @Override
+    public void onViewRecycled(@NonNull ViewFilesHolder holder) {
+        super.onViewRecycled(holder);
+        holder.checkBox.setChecked(false);
     }
 
     /**
@@ -213,6 +232,11 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
 
     @Override
     public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
         return position;
     }
 


### PR DESCRIPTION
# Description

This is a really weird issue of which I do not have an explanation as to what is happening or why exactly it is happening. I was able to solve it by disabling the checked state of the checkboxes in the `onViewRecycled` method ([SO reference](https://stackoverflow.com/a/53487849/8342168)).
I *guess* the reason is because of `RecyclerView`'s recycling or caching behaviour ([Documentation for `onViewRecycled`](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.Adapter.html#onviewrecycled)).

Fixes #537 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
