### PR TITLE
Icon for 'Remove Duplicate Pages' changed

### DIFF
--- a/app/src/main/res/drawable/ic_remove_duplicate_square_black.xml
+++ b/app/src/main/res/drawable/ic_remove_duplicate_square_black.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="m3.2063,6c-0.114,0 -0.2063,0.0736 -0.2063,0.1659l0,14.6682c0,0.0916 0.0919,0.1659 0.2063,0.1659l14.5873,0c0.114,0 0.2063,-0.0736 0.2063,-0.1659l0,-14.6682c0,-0.0916 -0.0919,-0.1659 -0.2063,-0.1659l-14.5873,0l0,0zM7,5l12,0l0,12l3,0l0,-15l-15,0l0,3z"
+      android:fillColor="#000000"/>
+  <path
+      android:pathData="M5.9849,12.4239h8.8087v2.6678h-8.8087z"
+      android:strokeWidth="1.5"
+      android:fillColor="#fff"
+      android:strokeColor="#000"/>
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -201,7 +201,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1.0"
-                app:option_icon="@drawable/ic_remove_circle_black_24dp"
+                app:option_icon="@drawable/ic_remove_duplicate_square_black"
                 app:option_text="@string/remove_duplicate_pages" />
 
         </LinearLayout>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -64,7 +64,7 @@
                     android:title="@string/split_pdf"/>
                 <item
                     android:id="@+id/nav_remove_duplicate_pages"
-                    android:icon="@drawable/ic_remove_circle_black_24dp"
+                    android:icon="@drawable/ic_remove_duplicate_square_black"
                     android:title="@string/remove_duplicate_pages" />
                 <item
                     android:id="@+id/nav_compress_pdf"
@@ -72,7 +72,7 @@
                     android:title="@string/compress_pdf"/>
                 <item
                     android:id="@+id/nav_invert_pdf"
-                    android:icon="@drawable/ic_remove_circle_black_24dp"
+                    android:icon="@drawable/ic_invert_color_24dp"
                     android:title="@string/invert_pdf" />
 
             </menu>


### PR DESCRIPTION
The icon for 'Remove Duplicate Pages' has been changed in the homescreen and in the navigation menu.
The changes have been tested multiple times through mobile interface.

Fixes #561 