### PR TITLE
Fix #602 Back button leads to Home Fragment when orange file selector…

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -64,6 +64,7 @@ import static swati4star.createpdf.util.Constants.REMOVE_PWd;
 import static swati4star.createpdf.util.Constants.REORDER_PAGES;
 import static swati4star.createpdf.util.Constants.SHOW_WELCOME_ACT;
 import static swati4star.createpdf.util.Constants.VERSION_NAME;
+import static swati4star.createpdf.util.Constants.stateBottomSheet;
 import static swati4star.createpdf.util.DialogUtils.ADD_WATERMARK;
 
 public class MainActivity extends AppCompatActivity
@@ -271,6 +272,10 @@ public class MainActivity extends AppCompatActivity
                     .findFragmentById(R.id.content);
             if (currentFragment instanceof HomeFragment) {
                 checkDoubleBackPress();
+            } else if (mSharedPreferences.getBoolean(stateBottomSheet, true)) {
+                getSupportFragmentManager().beginTransaction().detach(currentFragment)
+                        .attach(currentFragment).commit();
+                mSharedPreferences.edit().putBoolean(stateBottomSheet, false).apply();
             } else {
                 Fragment fragment = new HomeFragment();
                 getSupportFragmentManager().beginTransaction().replace(R.id.content, fragment).commit();

--- a/app/src/main/java/swati4star/createpdf/util/BottomSheetUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/BottomSheetUtils.java
@@ -1,7 +1,10 @@
 package swati4star.createpdf.util;
 
 import android.app.Activity;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.design.widget.BottomSheetBehavior;
+import static swati4star.createpdf.util.Constants.stateBottomSheet;
 
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
 
@@ -14,9 +17,13 @@ public class BottomSheetUtils  {
     }
 
     public void showHideSheet(BottomSheetBehavior sheetBehavior) {
+        SharedPreferences mSharedPreferences;
+        mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);
         if (sheetBehavior.getState() != BottomSheetBehavior.STATE_EXPANDED) {
+            mSharedPreferences.edit().putBoolean(stateBottomSheet, true).apply();
             sheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
         } else {
+            mSharedPreferences.edit().putBoolean(stateBottomSheet, false).apply();
             sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
         }
     }

--- a/app/src/main/java/swati4star/createpdf/util/Constants.java
+++ b/app/src/main/java/swati4star/createpdf/util/Constants.java
@@ -68,4 +68,6 @@ public class Constants {
 
     public static final String VERSION_NAME = "VERSION_NAME";
 
+    public static final String stateBottomSheet = "state_of_bottomsheet";
+
 }


### PR DESCRIPTION
# Description

Now, Back button leads to the desired fragment instead of main activity

Fixes #602

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
