### PR TITLE
Fix 602 Back button leads to Home Fragment when orange file selector is still open

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -77,6 +77,7 @@ public class MainActivity extends AppCompatActivity
     private NavigationView mNavigationView;
     private SharedPreferences mSharedPreferences;
     private boolean mDoubleBackToExitPressedOnce = false;
+    private Fragment mCurrentFragment;
 
 
     @Override
@@ -294,16 +295,67 @@ public class MainActivity extends AppCompatActivity
         if (drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawer(GravityCompat.START);
         } else {
-            Fragment currentFragment = getSupportFragmentManager()
+            mCurrentFragment = getSupportFragmentManager()
                     .findFragmentById(R.id.content);
-            if (currentFragment instanceof HomeFragment) {
+            if (mCurrentFragment instanceof HomeFragment) {
                 checkDoubleBackPress();
-            } else {
+            } else if (checkFragmentBottomSheetBehavior())
+                closeFragmentBottomSheet();
+            else {
                 Fragment fragment = new HomeFragment();
                 getSupportFragmentManager().beginTransaction().replace(R.id.content, fragment).commit();
                 setDefaultMenuSelected(0);
             }
         }
+    }
+
+    public boolean checkFragmentBottomSheetBehavior() {
+        if (mCurrentFragment instanceof InvertPdfFragment )
+            return ((InvertPdfFragment) mCurrentFragment).checkSheetBehaviour();
+
+        if (mCurrentFragment instanceof MergeFilesFragment )
+            return ((MergeFilesFragment) mCurrentFragment).checkSheetBehaviour();
+
+        if (mCurrentFragment instanceof RemoveDuplicatePagesFragment )
+            return ((RemoveDuplicatePagesFragment) mCurrentFragment).checkSheetBehaviour();
+
+        if (mCurrentFragment instanceof RemovePagesFragment )
+            return ((RemovePagesFragment) mCurrentFragment).checkSheetBehaviour();
+
+        if (mCurrentFragment instanceof AddImagesFragment )
+            return ((AddImagesFragment) mCurrentFragment).checkSheetBehaviour();
+
+        if (mCurrentFragment instanceof PdfToImageFragment )
+            return ((PdfToImageFragment) mCurrentFragment).checkSheetBehaviour();
+
+        if (mCurrentFragment instanceof SplitFilesFragment )
+            return ((SplitFilesFragment) mCurrentFragment).checkSheetBehaviour();
+
+        return false;
+    }
+
+    private void closeFragmentBottomSheet() {
+        if ( mCurrentFragment instanceof InvertPdfFragment)
+            ((InvertPdfFragment) mCurrentFragment).onBackPressed();
+
+        if (mCurrentFragment instanceof MergeFilesFragment)
+            ((MergeFilesFragment) mCurrentFragment).onBackPressed();
+
+        if (mCurrentFragment instanceof RemoveDuplicatePagesFragment )
+            ((RemoveDuplicatePagesFragment) mCurrentFragment).onBackPressed();
+
+        if (mCurrentFragment instanceof RemovePagesFragment)
+            ((RemovePagesFragment) mCurrentFragment).onBackPressed();
+
+        if (mCurrentFragment instanceof AddImagesFragment)
+            ((AddImagesFragment) mCurrentFragment).onBackPressed();
+
+        if (mCurrentFragment instanceof PdfToImageFragment)
+            ((PdfToImageFragment) mCurrentFragment).onBackPressed();
+
+        if (mCurrentFragment instanceof SplitFilesFragment)
+            ((SplitFilesFragment) mCurrentFragment).onBackPressed();
+
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/fragment/AddImagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/AddImagesFragment.java
@@ -36,6 +36,7 @@ import butterknife.OnClick;
 import swati4star.createpdf.R;
 import swati4star.createpdf.adapter.MergeFilesAdapter;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.util.BottomSheetCallback;
 import swati4star.createpdf.util.BottomSheetUtils;
 import swati4star.createpdf.util.FileUtils;
@@ -54,7 +55,8 @@ import static swati4star.createpdf.util.FileUriUtils.getFilePath;
 import static swati4star.createpdf.util.StringUtils.hideKeyboard;
 import static swati4star.createpdf.util.StringUtils.showSnackbar;
 
-public class AddImagesFragment extends Fragment implements BottomSheetPopulate, MergeFilesAdapter.OnClickListener {
+public class AddImagesFragment extends Fragment implements BottomSheetPopulate,
+        MergeFilesAdapter.OnClickListener, OnBackPressedInterface {
 
     private Activity mActivity;
     private String mPath;
@@ -277,5 +279,16 @@ public class AddImagesFragment extends Fragment implements BottomSheetPopulate, 
     @Override
     public void onPopulate(ArrayList<String> paths) {
         populateUtil(mActivity, paths, this, mLayout, mLottieProgress, mRecyclerViewFiles);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/InvertPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/InvertPdfFragment.java
@@ -36,6 +36,7 @@ import swati4star.createpdf.adapter.FilesListAdapter;
 import swati4star.createpdf.adapter.MergeFilesAdapter;
 import swati4star.createpdf.database.DatabaseHelper;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.interfaces.OnPDFCreatedInterface;
 import swati4star.createpdf.util.BottomSheetCallback;
 import swati4star.createpdf.util.BottomSheetUtils;
@@ -53,7 +54,7 @@ import static swati4star.createpdf.util.StringUtils.getSnackbarwithAction;
 import static swati4star.createpdf.util.StringUtils.showSnackbar;
 
 public class InvertPdfFragment extends Fragment implements MergeFilesAdapter.OnClickListener,
-        FilesListAdapter.OnFileItemClickedListener, BottomSheetPopulate, OnPDFCreatedInterface {
+        FilesListAdapter.OnFileItemClickedListener, BottomSheetPopulate, OnPDFCreatedInterface, OnBackPressedInterface {
 
     private Activity mActivity;
     private String mPath;
@@ -202,5 +203,17 @@ public class InvertPdfFragment extends Fragment implements MergeFilesAdapter.OnC
         viewPdfButton(path);
         resetValues();
     }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
+    }
 }
+
 

--- a/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
@@ -43,6 +43,7 @@ import swati4star.createpdf.adapter.MergeSelectedFilesAdapter;
 import swati4star.createpdf.database.DatabaseHelper;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
 import swati4star.createpdf.interfaces.MergeFilesListener;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.interfaces.OnItemClickListner;
 import swati4star.createpdf.model.EnhancementOptionsEntity;
 import swati4star.createpdf.util.BottomSheetCallback;
@@ -68,7 +69,8 @@ import static swati4star.createpdf.util.StringUtils.getSnackbarwithAction;
 import static swati4star.createpdf.util.StringUtils.showSnackbar;
 
 public class MergeFilesFragment extends Fragment implements MergeFilesAdapter.OnClickListener, MergeFilesListener,
-        MergeSelectedFilesAdapter.OnFileItemClickListener, OnItemClickListner, BottomSheetPopulate {
+        MergeSelectedFilesAdapter.OnFileItemClickListener, OnItemClickListner,
+        BottomSheetPopulate, OnBackPressedInterface {
     private Activity mActivity;
     private String mCheckbtClickTag = "";
     private static final int INTENT_REQUEST_PICKFILE_CODE = 10;
@@ -387,5 +389,16 @@ public class MergeFilesFragment extends Fragment implements MergeFilesAdapter.On
             mRecyclerViewFiles.addItemDecoration(new ViewFilesDividerItemDecoration(mActivity));
         }
         mLottieProgress.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/PdfToImageFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/PdfToImageFragment.java
@@ -35,6 +35,7 @@ import swati4star.createpdf.adapter.ExtractImagesAdapter;
 import swati4star.createpdf.adapter.MergeFilesAdapter;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
 import swati4star.createpdf.interfaces.ExtractImagesListener;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.util.BottomSheetCallback;
 import swati4star.createpdf.util.BottomSheetUtils;
 import swati4star.createpdf.util.CommonCodeUtils;
@@ -52,7 +53,7 @@ import static swati4star.createpdf.util.DialogUtils.createAnimationDialog;
 import static swati4star.createpdf.util.FileUriUtils.getFilePath;
 
 public class PdfToImageFragment extends Fragment implements BottomSheetPopulate, MergeFilesAdapter.OnClickListener,
-        ExtractImagesListener, ExtractImagesAdapter.OnFileItemClickedListener {
+        ExtractImagesListener, ExtractImagesAdapter.OnFileItemClickedListener, OnBackPressedInterface {
 
     private static final int INTENT_REQUEST_PICKFILE_CODE = 10;
     private Activity mActivity;
@@ -273,5 +274,16 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
     @Override
     public void onPopulate(ArrayList<String> paths) {
         populateUtil(mActivity, paths, this, mLayout, mLottieProgress, mRecyclerViewFiles);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            mSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return mSheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/RemoveDuplicatePagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/RemoveDuplicatePagesFragment.java
@@ -31,6 +31,7 @@ import swati4star.createpdf.adapter.FilesListAdapter;
 import swati4star.createpdf.adapter.MergeFilesAdapter;
 import swati4star.createpdf.database.DatabaseHelper;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.interfaces.OnPDFCreatedInterface;
 import swati4star.createpdf.util.BottomSheetCallback;
 import swati4star.createpdf.util.BottomSheetUtils;
@@ -47,7 +48,7 @@ import static swati4star.createpdf.util.StringUtils.getSnackbarwithAction;
 import static swati4star.createpdf.util.StringUtils.showSnackbar;
 
 public class RemoveDuplicatePagesFragment extends Fragment implements MergeFilesAdapter.OnClickListener,
-        FilesListAdapter.OnFileItemClickedListener, BottomSheetPopulate, OnPDFCreatedInterface {
+        FilesListAdapter.OnFileItemClickedListener, BottomSheetPopulate, OnPDFCreatedInterface, OnBackPressedInterface {
 
     private Activity mActivity;
     private String mPath;
@@ -193,6 +194,17 @@ public class RemoveDuplicatePagesFragment extends Fragment implements MergeFiles
                 .setAction(R.string.snackbar_viewAction, v -> mFileUtils.openFile(path)).show();
         viewPdfButton(path);
         resetValues();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
     }
 }
 

--- a/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/RemovePagesFragment.java
@@ -39,6 +39,7 @@ import swati4star.createpdf.activity.RearrangePdfPages;
 import swati4star.createpdf.adapter.MergeFilesAdapter;
 import swati4star.createpdf.database.DatabaseHelper;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.interfaces.OnPDFCompressedInterface;
 import swati4star.createpdf.util.BottomSheetCallback;
 import swati4star.createpdf.util.BottomSheetUtils;
@@ -66,7 +67,7 @@ import static swati4star.createpdf.util.StringUtils.hideKeyboard;
 import static swati4star.createpdf.util.StringUtils.showSnackbar;
 
 public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.OnClickListener,
-        OnPDFCompressedInterface, BottomSheetPopulate {
+        OnPDFCompressedInterface, BottomSheetPopulate, OnBackPressedInterface {
 
     private Activity mActivity;
     private String mPath;
@@ -325,5 +326,16 @@ public class RemovePagesFragment extends Fragment implements MergeFilesAdapter.O
     @Override
     public void onPopulate(ArrayList<String> paths) {
         populateUtil(mActivity, paths, this, mLayout, mLottieProgress, mRecyclerViewFiles);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
@@ -33,6 +33,7 @@ import swati4star.createpdf.R;
 import swati4star.createpdf.adapter.FilesListAdapter;
 import swati4star.createpdf.adapter.MergeFilesAdapter;
 import swati4star.createpdf.interfaces.BottomSheetPopulate;
+import swati4star.createpdf.interfaces.OnBackPressedInterface;
 import swati4star.createpdf.util.BottomSheetCallback;
 import swati4star.createpdf.util.BottomSheetUtils;
 import swati4star.createpdf.util.FileUtils;
@@ -49,7 +50,7 @@ import static swati4star.createpdf.util.StringUtils.hideKeyboard;
 import static swati4star.createpdf.util.StringUtils.showSnackbar;
 
 public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.OnClickListener,
-        FilesListAdapter.OnFileItemClickedListener, BottomSheetPopulate {
+        FilesListAdapter.OnFileItemClickedListener, BottomSheetPopulate, OnBackPressedInterface {
 
     private Activity mActivity;
     private String mPath;
@@ -208,5 +209,16 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
     @Override
     public void onPopulate(ArrayList<String> paths) {
         populateUtil(mActivity, paths, this, mLayout, mLottieProgress, mRecyclerViewFiles);
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (checkSheetBehaviour())
+            sheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+    }
+
+    @Override
+    public boolean checkSheetBehaviour() {
+        return sheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/interfaces/OnBackPressedInterface.java
+++ b/app/src/main/java/swati4star/createpdf/interfaces/OnBackPressedInterface.java
@@ -1,0 +1,6 @@
+package swati4star.createpdf.interfaces;
+
+public interface OnBackPressedInterface {
+    void onBackPressed();
+    boolean checkSheetBehaviour();
+}


### PR DESCRIPTION


Fixes #602 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)



Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
