### PR TITLE
Fix #626 'Get-Started Opens ImagesToPdfFragment'

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java
@@ -132,7 +132,7 @@ public class HistoryFragment extends Fragment implements HistoryAdapter.OnClickL
 
     @OnClick(R.id.getStarted)
     public void loadHome() {
-        Fragment fragment = new ImageToPdfFragment();
+        Fragment fragment = new HomeFragment();
         FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
         fragmentManager.beginTransaction().replace(R.id.content, fragment).commit();
         if (getActivity() instanceof MainActivity) {

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -288,7 +288,7 @@ public class ViewFilesFragment extends Fragment
     //When the "GET STARTED" button is clicked, the user is taken to home
     @OnClick(R.id.getStarted)
     public void loadHome() {
-        Fragment fragment = new ImageToPdfFragment();
+        Fragment fragment = new HomeFragment();
         FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
         fragmentManager.beginTransaction().replace(R.id.content, fragment).commit();
         //Set default item selected


### PR DESCRIPTION
# Description

- In [ViewFilesFragment](https://github.com/Swati4star/Images-to-PDF/blob/master/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java) & [HistoryFragment](https://github.com/Swati4star/Images-to-PDF/blob/master/app/src/main/java/swati4star/createpdf/fragment/HistoryFragment.java), clicking on **Get Started** now opens [HomeFragment](https://github.com/Swati4star/Images-to-PDF/blob/master/app/src/main/java/swati4star/createpdf/fragment/HomeFragment.java) instead of [ImageToPdfFragment](https://github.com/Swati4star/Images-to-PDF/blob/master/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java)

![](https://i.imgur.com/LDwwMHq.gif)

Fixes #626

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
