### PR TITLE
In AboutUsFragment - In first CardView, 2 TextViews are not aligned in same line.

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/AboutUsFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/AboutUsFragment.java
@@ -32,7 +32,8 @@ public class AboutUsFragment extends Fragment {
         try {
             PackageInfo packageInfo = mActivity.getPackageManager().getPackageInfo(mActivity.getPackageName(), 0);
             TextView versionText = rootview.findViewById(R.id.version_value);
-            versionText.setText(packageInfo.versionName);
+            String version = versionText.getText().toString() + " " + packageInfo.versionName;
+            versionText.setText(version);
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
         }

--- a/app/src/main/res/layout/fragment_about_us.xml
+++ b/app/src/main/res/layout/fragment_about_us.xml
@@ -49,6 +49,7 @@
                 android:layout_height="50dp">
 
                 <TextView
+                    android:id="@+id/version_value"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
@@ -58,13 +59,6 @@
                     android:padding="8dp"
                     android:text="@string/version"
                     tools:targetApi="m" />
-
-                <TextView
-                    android:id="@+id/version_value"
-
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical" />
 
             </LinearLayout>
 


### PR DESCRIPTION
# Description
- In [AboutUsFragment](https://github.com/Swati4star/Images-to-PDF/blob/master/app/src/main/java/swati4star/createpdf/fragment/AboutUsFragment.java) - In first CardView, 2 TextViews ("Version : " & Version Number) are now aligned in same line.

**Screenshot**

![App Screenshot](https://i.imgur.com/tefEz8j.png)

Fixes #649

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
