### PR TITLE
Remove stale 'view pdf' button from InvertPdfFragment

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/InvertPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/InvertPdfFragment.java
@@ -132,6 +132,8 @@ public class InvertPdfFragment extends Fragment implements MergeFilesAdapter.OnC
 
     private void setTextAndActivateButtons(String path) {
         mPath = path;
+        // Remove stale "View PDF" button
+        mViewPdf.setVisibility(View.GONE);
         mMorphButtonUtility.setTextAndActivateButtons(path,
                 selectFileButton, invertPdfButton);
     }
@@ -188,8 +190,6 @@ public class InvertPdfFragment extends Fragment implements MergeFilesAdapter.OnC
         mMaterialDialog.dismiss();
         if (!isNewPdfCreated) {
             showSnackbar(mActivity, R.string.snackbar_invert_unsuccessful);
-            //Hiding View PDF button
-            mViewPdf.setVisibility(View.GONE);
             return;
         }
         new DatabaseHelper(mActivity).insertRecord(path, mActivity.getString(R.string.snackbar_invert_successfull));
@@ -207,5 +207,4 @@ public class InvertPdfFragment extends Fragment implements MergeFilesAdapter.OnC
         return checkSheetBehaviourUtil(sheetBehavior);
     }
 }
-
 


### PR DESCRIPTION
Fixes #671

As a note - I am new to this project, but from a quick look around, it looks like this issue exists in other features as well. The only other ones I have taken a look at are Remove Pages and Reorder Pages and they both exhibit the same behavior. The fix would probably be similar for other features.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
