### PR TITLE
Fix #678

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
@@ -185,7 +185,7 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
     }
 
     /**
-         * Gets the total number of pages in the
+     * Gets the total number of pages in the
      * selected PDF and returns them in
      * default format for single page pdfs
      * (1,2,3,4,5,)

--- a/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
@@ -130,6 +130,10 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
         ArrayList<String> outputFilePaths = mPDFUtils.splitPDFByConfig(mPath,
                 mSplitConfitEditText.getText().toString());
         int numberOfPages = outputFilePaths.size();
+        if (numberOfPages == 1) {
+            showSnackbar(getActivity(), R.string.split_one_page_pdf_alert);
+            return;
+        }
         if (numberOfPages > 0) {
             String output = String.format(mActivity.getString(R.string.split_success), numberOfPages);
             showSnackbar(mActivity, output);
@@ -175,10 +179,13 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
                 selectFileButton, splitFilesButton);
         mSplitConfitEditText.setVisibility(View.VISIBLE);
         mSplitConfitEditText.setText(getDefaultSplitConfig(mPath));
+        if (mPDFUtils.splitPDFByConfig(mPath, mSplitConfitEditText.getText().toString()).size() == 1) {
+            showSnackbar(getActivity(), R.string.split_one_page_pdf_alert);
+        }
     }
 
     /**
-     * Gets the total number of pages in the
+         * Gets the total number of pages in the
      * selected PDF and returns them in
      * default format for single page pdfs
      * (1,2,3,4,5,)

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -407,4 +407,5 @@
     <string name="page_color">Page Color</string>
     <string name="add_to_favourite">Add to Favourite</string>
     <string name="favourites">Favourites</string>
+    <string name="split_one_page_pdf_alert">¡El PDF seleccionado no se puede dividir porque solo tiene 1 página!</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -409,4 +409,5 @@
     <string name="select_excel_file">Select Excel file</string>
     <string name="add_to_favourite">Add to Favourite</string>
     <string name="favourites">Favourites</string>
+    <string name="split_one_page_pdf_alert">Le PDF sélectionné ne peut pas être divisé car il ne contient qu\'une page!</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -407,4 +407,5 @@
     <string name="select_excel_file">Select Excel file</string>
     <string name="add_to_favourite">Add to Favourite</string>
     <string name="favourites">Favourites</string>
+    <string name="split_one_page_pdf_alert">選択したPDFは1ページしかないため分割できません。</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -450,4 +450,5 @@
     <string name="select_excel_file">Select Excel file</string>
     <string name="add_to_favourite">Add to Favourite</string>
     <string name="favourites">Favourites</string>
+    <string name="split_one_page_pdf_alert">Выбранный PDF не может быть разделен, потому что он имеет только 1 страницу!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -353,6 +353,7 @@
     <string name="error_page_number">Invalid page number</string>
     <string name="error_page_range">Invalid range input</string>
     <string name="error_invalid_input">Invalid input</string>
+    <string name="split_one_page_pdf_alert">Selected PDF can\'t be split because it has only 1 page!</string>
 
     <!-- Remove Pages -->
     <string name="remove_pages">Remove Pages</string>


### PR DESCRIPTION
# Description

- PDF with only 1 page can't be split & a message in shown when user tries to do the same.
- String required for the same is translated in all the supported languages by app.

**Demo**
<img src="https://imgur.com/h4WxQ8G.gif" width=300>

Fixes #678

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
