### PR TITLE
icon fix

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -116,11 +116,11 @@
                         android:title="@string/extract_images" />
                     <item
                         android:id="@+id/nav_pdf_to_images"
-                        android:icon="@drawable/ic_zip_to_pdf"
+                        android:icon="@drawable/ic_image_black_24dp"
                         android:title="@string/pdf_to_images" />
                     <item
                         android:id="@+id/nav_zip_to_pdf"
-                        android:icon="@drawable/ic_image_black_24dp"
+                        android:icon="@drawable/ic_zip_to_pdf"
                         android:title="@string/zip_to_pdf" />
                 </group>
             </menu>


### PR DESCRIPTION
# Description
correct icon for zipToPdf and pdfToImages in nav drawer

![Screenshot_20190501-102020](https://user-images.githubusercontent.com/20037625/57006037-f0f38d00-6bfa-11e9-8644-ea0d163d41d6.png)

Fixes #743 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings