### PR TITLE
Solve Bug in Split pdf

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
@@ -11,6 +11,7 @@ import android.support.design.widget.BottomSheetBehavior;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -114,8 +115,9 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) throws NullPointerException {
-        if (data == null || resultCode != RESULT_OK || data.getData() == null)
-            return;
+        if (data == null || resultCode != RESULT_OK || data.getData() == null) {
+            resetValues();
+        }
         if (requestCode == INTENT_REQUEST_PICKFILE_CODE) {
             //Getting Absolute Path
             String path = RealPathUtil.getRealPath(getContext(), data.getData());
@@ -172,13 +174,13 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
         mSplittedFiles.setVisibility(View.GONE);
         splitFilesSuccessText.setVisibility(View.GONE);
         mPath = path;
-        mMorphButtonUtility.setTextAndActivateButtons(path,
-                selectFileButton, splitFilesButton);
-        mSplitConfitEditText.setVisibility(View.VISIBLE);
         String defaultSplitConfig = getDefaultSplitConfig(mPath);
-        if (defaultSplitConfig != null)
+        if (defaultSplitConfig != null) {
+            mMorphButtonUtility.setTextAndActivateButtons(path,
+                    selectFileButton, splitFilesButton);
+            mSplitConfitEditText.setVisibility(View.VISIBLE);
             mSplitConfitEditText.setText(defaultSplitConfig);
-        else
+        } else
             resetValues();
     }
 

--- a/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SplitFilesFragment.java
@@ -11,7 +11,6 @@ import android.support.design.widget.BottomSheetBehavior;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -115,9 +114,8 @@ public class SplitFilesFragment extends Fragment implements MergeFilesAdapter.On
     }
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) throws NullPointerException {
-        if (data == null || resultCode != RESULT_OK || data.getData() == null) {
-            resetValues();
-        }
+        if (data == null || resultCode != RESULT_OK || data.getData() == null)
+            return;
         if (requestCode == INTENT_REQUEST_PICKFILE_CODE) {
             //Getting Absolute Path
             String path = RealPathUtil.getRealPath(getContext(), data.getData());


### PR DESCRIPTION
# Description
Split pdf button doesn't get blue when a user selects a password protected pdf.

Fixes #(issue)
#751 solved

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
