### PR TITLE
added option to set transparency of watermark

### DIFF
--- a/app/src/main/res/layout/add_watermark_dialog.xml
+++ b/app/src/main/res/layout/add_watermark_dialog.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:picker="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:padding="24dp">
 
@@ -51,7 +52,8 @@
     <com.github.danielnilsson9.colorpickerview.view.ColorPickerView
         android:id="@+id/watermarkColor"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        picker:alphaChannelVisible="true"/>
 
     <TextView
         android:id="@+id/enter_watermark_font_size"


### PR DESCRIPTION
# Description
library used for color picker view already includes a way to set transparency of color. so instead of making a new option to set transparency, I feel this approach is better

![Screenshot_20190521-090931](https://user-images.githubusercontent.com/20037625/58066754-4d1d5180-7ba8-11e9-8efb-e1219af88709.png)

Fixes #762 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
