### PR TITLE
Fix the ViewFiles toolbar on returning from Favourites Section.

### DIFF
--- a/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
@@ -397,6 +397,11 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
 
     }
 
+    @Override
+    public void filesPopulated() {
+
+    }
+
     public class ViewFilesHolder extends RecyclerView.ViewHolder {
 
         @BindView(R.id.fileRipple)

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -292,6 +292,16 @@ public class ViewFilesFragment extends Fragment
         noPermissionsLayout.setVisibility(View.GONE);
     }
 
+    @Override
+    public void filesPopulated() {
+        //refresh eveything and invalidate the menu.
+        if (mIsMergeRequired) {
+            mIsMergeRequired = false;
+            mIsAllFilesSelected = false;
+            mActivity.invalidateOptionsMenu();
+        }
+    }
+
     //When the "GET STARTED" button is clicked, the user is taken to home
     @OnClick(R.id.getStarted)
     public void loadHome() {
@@ -362,8 +372,7 @@ public class ViewFilesFragment extends Fragment
 
     /**
      * Updates the toolbar with respective the number of files selected.
-     *
-     * */
+     */
     public void updateToolbar() {
         AppCompatActivity activity = ((AppCompatActivity)
                 Objects.requireNonNull(mActivity));

--- a/app/src/main/java/swati4star/createpdf/interfaces/EmptyStateChangeListener.java
+++ b/app/src/main/java/swati4star/createpdf/interfaces/EmptyStateChangeListener.java
@@ -5,4 +5,5 @@ public interface EmptyStateChangeListener {
     void setEmptyStateInvisible();
     void showNoPermissionsView();
     void hideNoPermissionsView();
+    void filesPopulated();
 }

--- a/app/src/main/java/swati4star/createpdf/util/PopulateList.java
+++ b/app/src/main/java/swati4star/createpdf/util/PopulateList.java
@@ -74,6 +74,7 @@ public class PopulateList extends AsyncTask<Void, Void, Void> {
             List<PDFFile> pdfFilesWithEncryptionStatus = getPdfFilesWithEncryptionStatus(pdfFiles);
             mHandler.post(mEmptyStateChangeListener::hideNoPermissionsView);
             mHandler.post(() -> mAdapter.setData(pdfFilesWithEncryptionStatus));
+            mHandler.post(mEmptyStateChangeListener::filesPopulated);
         }
     }
 


### PR DESCRIPTION
# Description
Added the Interface method `filesPopulated ` to get the callback when all files are populated and thereafter resetting the variables `mIsMergeRequired` and `mIsAllFilesSelected` and invalidate the menu.

Fixes #766 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
