### PR TITLE
Split pdf files hidden by bottom sheet fixed

### DIFF
--- a/app/src/main/res/layout/fragment_split_files.xml
+++ b/app/src/main/res/layout/fragment_split_files.xml
@@ -11,6 +11,7 @@
         android:layout_height="match_parent"
         android:orientation="vertical"
         android:stretchColumns="*"
+        android:layout_marginBottom="40dp"
         tools:context=".fragment.AddImagesFragment">
 
         <com.dd.morphingbutton.MorphingButton


### PR DESCRIPTION
# Description

<td><img src = "https://user-images.githubusercontent.com/31350501/58424154-6c3e4680-80b4-11e9-9f5c-a77314eeb0c3.jpeg" height = "480" width="270"></td>

Fixes #767

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
