### PR TITLE
Fixed text file error and added file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 /build
 /captures
 app/release/
-java_pid8116.hprof
+java_pid*.hprof

--- a/app/src/main/java/swati4star/createpdf/fragment/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/TextToPdfFragment.java
@@ -43,6 +43,7 @@ import swati4star.createpdf.model.EnhancementOptionsEntity;
 import swati4star.createpdf.model.TextToPDFOptions;
 import swati4star.createpdf.util.ColorUtils;
 import swati4star.createpdf.util.Constants;
+import swati4star.createpdf.util.DirectoryUtils;
 import swati4star.createpdf.util.FileUtils;
 import swati4star.createpdf.util.MorphButtonUtility;
 import swati4star.createpdf.util.PageSizeUtils;
@@ -68,6 +69,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
 
     private Activity mActivity;
     private FileUtils mFileUtils;
+    private DirectoryUtils mDirectoryUtils;
 
     private final int mFileSelectCode = 0;
     private Uri mTextFileUri = null;
@@ -85,8 +87,8 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
 
     @BindView(R.id.enhancement_options_recycle_view_text)
     RecyclerView mTextEnhancementOptionsRecycleView;
-    @BindView(R.id.tv_file_name)
-    TextView mTextView;
+    @BindView(R.id.selectFile)
+    MorphingButton mSelectFile;
     @BindView(R.id.createtextpdf)
     MorphingButton mCreateTextPdf;
 
@@ -384,9 +386,8 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
      * @param mFilename name of file to be created.
      */
     private void createPdf(String mFilename) {
-        mPath = mSharedPreferences.getString(STORAGE_LOCATION,
-                getDefaultStorageLocation());
-        mPath = mPath + mFilename + mActivity.getString(R.string.pdf_ext);
+        mPath = mDirectoryUtils.getOrCreatePdfDirectory().getPath();
+        mPath = mPath + "/" + mFilename + mActivity.getString(R.string.pdf_ext);
         TextToPDFOptions options = new TextToPDFOptions(mFilename, PageSizeUtils.mPageSize, mPasswordProtected,
                 mPassword, mTextFileUri, mFontSize, mFontFamily, mFontColor, mPageColor);
         TextToPDFUtils fileUtil = new TextToPDFUtils(mActivity);
@@ -441,8 +442,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
                         }
                     }
                     fileName = getString(R.string.text_file_name) + fileName;
-                    mTextView.setText(fileName);
-                    mTextView.setVisibility(View.VISIBLE);
+                    mSelectFile.setText(fileName);
                     mCreateTextPdf.setEnabled(true);
                     mMorphButtonUtility.morphToSquare(mCreateTextPdf, mMorphButtonUtility.integer());
                 }
@@ -456,6 +456,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
         super.onAttach(context);
         mActivity = (Activity) context;
         mFileUtils = new FileUtils(mActivity);
+        mDirectoryUtils = new DirectoryUtils(mActivity);
     }
 
     @Override
@@ -515,7 +516,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
         }
         getSnackbarwithAction(mActivity, R.string.snackbar_pdfCreated)
                 .setAction(R.string.snackbar_viewAction, v -> mFileUtils.openFile(mPath)).show();
-        mTextView.setVisibility(View.GONE);
+        mSelectFile.setText(R.string.select_text_file);
         mMorphButtonUtility.morphToGrey(mCreateTextPdf, mMorphButtonUtility.integer());
         mCreateTextPdf.setEnabled(false);
         mTextFileUri = null;


### PR DESCRIPTION
# Description

Fixed the "Error Occurred" when trying to convert  ```Text to PDF ``` before converting  ```Images to PDF ```.

```Select Text File``` button now shows file name after user selects the file to be converted.
* The bottom TextView which displayed the file name has been removed.

![screenshot1](https://user-images.githubusercontent.com/55661063/66262617-fc636980-e7d3-11e9-9959-df49487bd7e7.png)

![screenshot2](https://user-images.githubusercontent.com/55661063/66262705-0df94100-e7d5-11e9-85ee-15b112d0aa20.png)

Fixes #777 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
