### PR TITLE
Wrong paper sizes for DIN A/B(x) formats in "Set Page Size" dialogue

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,31 +41,31 @@
     </array>
 
     <string-array name="array_page_sizes_b0_b10" translatable="false">
-        <item>B0 (2834 x 4008)</item>
-        <item>B1 (2004 x 2834)</item>
-        <item>B2 (1417 x 2004)</item>
-        <item>B3 (1000 x 1417)</item>
-        <item>B4 (708 x 1000)</item>
-        <item>B5 (498 x 708)</item>
-        <item>B6 (354 x 498)</item>
-        <item>B7 (249 x 354)</item>
-        <item>B8 (175 x 249)</item>
-        <item>B9 (124 x 175)</item>
-        <item>B10 (87 x 124)</item>
+        <item>B0 (1000 x 1414 mm)</item>
+        <item>B1 (707 x 1000 mm)</item>
+        <item>B2 (500 x 707 mm)</item>
+        <item>B3 (353 x 500 mm)</item>
+        <item>B4 (250 x 353 mm)</item>
+        <item>B5 (176 x 250 mm)</item>
+        <item>B6 (125 x 176 mm)</item>
+        <item>B7 (88 x 125 mm)</item>
+        <item>B8 (62 x 88 mm)</item>
+        <item>B9 (44 x 62 mm)</item>
+        <item>B10 (31 x 44 mm)</item>
     </string-array>
 
     <string-array name="array_page_sizes_a0_b10" translatable="false">
-        <item>A0 (2384 x 3370)</item>
-        <item>A1 (1684 x 2384)</item>
-        <item>A2 (1191 x 1684)</item>
-        <item>A3 (842 x 1191)</item>
-        <item>A4 (595 x 842)</item>
-        <item>A5 (420 x 595)</item>
-        <item>A6 (297 x 420)</item>
-        <item>A7 (210 x 297)</item>
-        <item>A8 (148 x 210)</item>
-        <item>A9 (105 x 148)</item>
-        <item>A10 (73 x 105)</item>
+        <item>A0 (841 x 1189 mm)</item>
+        <item>A1 (594 x 841 mm)</item>
+        <item>A2 (420 x 594 mm)</item>
+        <item>A3 (297 x 420 mm)</item>
+        <item>A4 (210 x 297 mm)</item>
+        <item>A5 (148 x 210 mm)</item>
+        <item>A6 (105 x 148 mm)</item>
+        <item>A7 (74 x 105 mm)</item>
+        <item>A8 (52 x 74 mm)</item>
+        <item>A9 (37 x 52 mm)</item>
+        <item>A10 (26 x 37 mm)</item>
     </string-array>
 
     <string-array name="fontStyles" translatable="false">


### PR DESCRIPTION
# Description
@just-Nob pointed out that the DIN A (and also DIN B) listed sizes were incorrect. They were listing 72ppi pixel values, so I've converted them to list mm values so they would be consistent across devices.

Fixes https://github.com/Swati4star/Images-to-PDF/issues/780

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Made sure that creating a PDF with size restrictions still worked.

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (Didn't see anywhere else that referenced those values)
- [x] My changes generate no new warnings