### PR TITLE
Issue #784 Fixing Crashes Related To Playstore

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/TextToPdfFragment.java
@@ -454,7 +454,12 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListner,
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        mActivity = (Activity) context;
+        if (context instanceof Activity) {
+            mActivity = (Activity) context;
+        } else {
+            mActivity = getActivity();
+        }
+
         mFileUtils = new FileUtils(mActivity);
         mDirectoryUtils = new DirectoryUtils(mActivity);
     }


### PR DESCRIPTION
# Description
The context received in the onAttach method is not always an Activity context so a check was added to make sure that the correct context is being passed.

You can find more information about these crashes [here](https://stackoverflow.com/questions/14429754/nullpointerexception-at-preferencemanager-getdefaultsharedpreferences-on-startup) and [here](https://stackoverflow.com/questions/32083053/android-fragment-onattach-deprecated).

**Code Added:**
`if (context instanceof Activity) {
            mActivity = (Activity) context;
        } else {
            mActivity = getActivity();
        }
`

#784 

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
