### PR TITLE
startup crash fix: added missing multidex dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'junit:junit:4.12'
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.android.support:support-v13:28.0.0'
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'


### PR DESCRIPTION
 Fixes #812 
App crashes on startup due to missing dependency.
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
