### PR TITLE
#759 Issue. Fixed getting absolute path in MergeFilesFragment.

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -52,7 +53,6 @@ import swati4star.createpdf.util.DialogUtils;
 import swati4star.createpdf.util.FileUtils;
 import swati4star.createpdf.util.MergePdf;
 import swati4star.createpdf.util.MorphButtonUtility;
-import swati4star.createpdf.util.RealPathUtil;
 import swati4star.createpdf.util.StringUtils;
 import swati4star.createpdf.util.ViewFilesDividerItemDecoration;
 
@@ -251,7 +251,8 @@ public class MergeFilesFragment extends Fragment implements MergeFilesAdapter.On
             return;
         if (requestCode == INTENT_REQUEST_PICKFILE_CODE) {
             //Getting Absolute Path
-            String path = RealPathUtil.getInstance().getRealPath(getContext(), data.getData());
+            Uri uri = data.getData();
+            String path = uri.getPath();
             mFilePaths.add(path);
             mMergeSelectedFilesAdapter.notifyDataSetChanged();
             StringUtils.getInstance().showSnackbar(mActivity, getString(R.string.pdf_added_to_list));


### PR DESCRIPTION
# Description

The current behavior of the application is not the same as in the description. Select files using BottomSheet works correctly. Only files are not marked X (CheckBox).

There was another problem.
Select files using the SELECT button did not work. The selected file has an incorrect path. The application could not access the file.

Fixes #759 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
