### PR TITLE
update: confirmation dialog before deleting files

### DIFF
--- a/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -254,8 +253,7 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
     }
 
     /**
-     * Shows an alert to delete file
-     * and deletes file on positive response
+     * Delete the file
      *
      * @param name     - name of the file
      * @param position - position of file in array list
@@ -264,92 +262,59 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
 
         if (position < 0 || position >= mFileList.size())
             return;
-        AlertDialog.Builder dialogAlert = new AlertDialog.Builder(mActivity)
-                .setCancelable(true)
-                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.dismiss())
-                .setTitle(R.string.delete_alert)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
-                    AtomicInteger undoClicked = new AtomicInteger();
-                    final File fdelete = new File(name);
-                    mFileList.remove(position);
-                    notifyDataSetChanged();
-                    StringUtils.getInstance().getSnackbarwithAction(mActivity, R.string.snackbar_file_deleted)
-                            .setAction(R.string.snackbar_undoAction, v -> {
-                                if (mFileList.size() == 0) {
-                                    mEmptyStateChangeListener.setEmptyStateInvisible();
-                                }
-                                updateDataset();
-                                undoClicked.set(1);
-                            }).addCallback(new Snackbar.Callback() {
-                                    @Override
-                                    public void onDismissed(Snackbar snackbar, int event) {
-                                        if (undoClicked.get() == 0) {
-                                            fdelete.delete();
-                                            mDatabaseHelper.insertRecord(fdelete.getAbsolutePath(),
-                                                    mActivity.getString(R.string.deleted));
-                                        }
-                                    }
-                            }).show();
-                    if (mFileList.size() == 0)
-                        mEmptyStateChangeListener.setEmptyStateVisible();
-                });
-        dialogAlert.create().show();
+
+        AtomicInteger undoClicked = new AtomicInteger();
+        final File fdelete = new File(name);
+        mFileList.remove(position);
+        notifyDataSetChanged();
+        StringUtils.getInstance().getSnackbarwithAction(mActivity, R.string.snackbar_file_deleted)
+                .setAction(R.string.snackbar_undoAction, v -> {
+                    if (mFileList.size() == 0) {
+                        mEmptyStateChangeListener.setEmptyStateInvisible();
+                    }
+                    updateDataset();
+                    undoClicked.set(1);
+                }).addCallback(new Snackbar.Callback() {
+                    @Override
+                    public void onDismissed(Snackbar snackbar, int event) {
+                        if (undoClicked.get() == 0) {
+                            fdelete.delete();
+                            mDatabaseHelper.insertRecord(fdelete.getAbsolutePath(),
+                                    mActivity.getString(R.string.deleted));
+                        }
+                    }
+                }).show();
+        if (mFileList.size() == 0)
+            mEmptyStateChangeListener.setEmptyStateVisible();
     }
 
     /**
-     * Shows an alert to delete file
-     * and iterates through filelist and deletes all elements
+     * iterate through filelist and remove all elements
      */
     public void deleteFiles() {
 
-        AlertDialog.Builder dialogAlert = new AlertDialog.Builder(mActivity)
-                .setCancelable(true)
-                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.dismiss())
-                .setTitle(R.string.delete_alert)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
-                    AtomicInteger undoClicked = new AtomicInteger();
-                    ArrayList<PDFFile> newList = new ArrayList<>();
-                    for (int position = 0; position < mFileList.size(); position++)
-                        if (!mSelectedFiles.contains(position))
-                            newList.add(mFileList.get(position));
+        for (int position : mSelectedFiles) {
 
-                    mSelectedFiles.clear();
-                    if (newList.size() == 0)
-                        mEmptyStateChangeListener.setEmptyStateVisible();
+            if (position >= mFileList.size())
+                continue;
 
-                    setData(newList);
-                    StringUtils.getInstance().getSnackbarwithAction(mActivity, R.string.snackbar_file_deleted)
-                            .setAction(R.string.snackbar_undoAction, v -> {
-                                if (mFileList.size() == 0) {
-                                    mEmptyStateChangeListener.setEmptyStateInvisible();
-                                }
-                                updateDataset();
-                                undoClicked.set(1);
-                            }).addCallback(new Snackbar.Callback() {
-                                    @Override
-                                    public void onDismissed(Snackbar snackbar, int event) {
-                                        if (undoClicked.get() == 0) {
-                                            for (int position : mSelectedFiles) {
+            String fileName = mFileList.get(position).getPdfFile().getPath();
+            File fdelete = new File(fileName);
+            mDatabaseHelper.insertRecord(fdelete.getAbsolutePath(), mActivity.getString(R.string.deleted));
+            if (fdelete.exists() && !fdelete.delete())
+                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_file_not_deleted);
+        }
 
-                                                if (position >= mFileList.size())
-                                                    continue;
+        ArrayList<PDFFile> newList = new ArrayList<>();
+        for (int position = 0; position < mFileList.size(); position++)
+            if (!mSelectedFiles.contains(position))
+                newList.add(mFileList.get(position));
 
-                                            String fileName = mFileList.get(position).getPdfFile().getPath();
-                                            File fdelete = new File(fileName);
-                                            mDatabaseHelper.insertRecord(fdelete.getAbsolutePath(),
-                                                    mActivity.getString(R.string.deleted));
-                                            if (fdelete.exists() && !fdelete.delete())
-                                                StringUtils.getInstance().showSnackbar(mActivity,
-                                                        R.string.snackbar_file_not_deleted);
-                                            }
-                                        }
-                                    }
-                            }).show();
-                    if (mFileList.size() == 0)
-                        mEmptyStateChangeListener.setEmptyStateVisible();
-                });
-        dialogAlert.create().show();
+        mSelectedFiles.clear();
+        if (newList.size() == 0)
+            mEmptyStateChangeListener.setEmptyStateVisible();
 
+        setData(newList);
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -170,7 +170,7 @@ public class ViewFilesFragment extends Fragment
                 break;
             case R.id.item_delete:
                 if (mViewFilesAdapter.areItemsSelected())
-                    deleteFiles();
+                    mViewFilesAdapter.deleteFiles();
                 else
                     StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_no_pdfs_selected);
                 break;
@@ -198,23 +198,6 @@ public class ViewFilesFragment extends Fragment
                 break;
         }
         return true;
-    }
-
-
-    /**
-     * Shows an alert to delete files
-     * and delete files on positive response
-     */
-    private void deleteFiles() {
-        AlertDialog.Builder dialogAlert = new AlertDialog.Builder(mActivity)
-                .setCancelable(true)
-                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.dismiss())
-                .setTitle(R.string.delete_alert)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
-                    mViewFilesAdapter.deleteFiles();
-                    checkIfListEmpty();
-                });
-        dialogAlert.create().show();
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -170,7 +170,7 @@ public class ViewFilesFragment extends Fragment
                 break;
             case R.id.item_delete:
                 if (mViewFilesAdapter.areItemsSelected())
-                    mViewFilesAdapter.deleteFiles();
+                    deleteFiles();
                 else
                     StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_no_pdfs_selected);
                 break;
@@ -198,6 +198,23 @@ public class ViewFilesFragment extends Fragment
                 break;
         }
         return true;
+    }
+
+
+    /**
+     * Shows an alert to delete files
+     * and delete files on positive response
+     */
+    private void deleteFiles() {
+        AlertDialog.Builder dialogAlert = new AlertDialog.Builder(mActivity)
+                .setCancelable(true)
+                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.dismiss())
+                .setTitle(R.string.delete_alert)
+                .setPositiveButton(R.string.yes, (dialog, which) -> {
+                    mViewFilesAdapter.deleteFiles();
+                    checkIfListEmpty();
+                });
+        dialogAlert.create().show();
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -201,20 +201,8 @@ public class ViewFilesFragment extends Fragment
     }
 
 
-    /**
-     * Shows an alert to delete files
-     * and delete files on positive response
-     */
     private void deleteFiles() {
-        AlertDialog.Builder dialogAlert = new AlertDialog.Builder(mActivity)
-                .setCancelable(true)
-                .setNegativeButton(R.string.cancel, (dialogInterface, i) -> dialogInterface.dismiss())
-                .setTitle(R.string.delete_alert)
-                .setPositiveButton(R.string.yes, (dialog, which) -> {
-                    mViewFilesAdapter.deleteFiles();
-                    checkIfListEmpty();
-                });
-        dialogAlert.create().show();
+        mViewFilesAdapter.deleteFile();
     }
 
     /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -224,7 +224,7 @@
     <string name="master_password_changed">Das Passwort scheint falsch zu sein. Möglicherweise haben Sie das Master-Passwort geändert.</string>
 
 
-    <string name="delete_alert">Möchten Sie alle ausgewählten Dateien löschen?</string>
+    <string name="delete_alert_selected">Möchten Sie alle ausgewählten Dateien löschen?</string>
     <string name="sort_by_title">Sortieren nach</string>
 
     
@@ -520,6 +520,8 @@
     <string name="no_excel_file">Keine Excel-Datei ausgewählt</string>
     <string name="split_range_alert">Der eingegebene geteilte Bereich erstellt das ausgewählte PDF erneut!</string>
     <string name="reordering_pages_dialog">Ordnen Sie Ihre Seiten neu...</string>
+    <string name="delete_alert_singular">Möchten Sie die ausgewählte Datei löschen?</string>
+    <string name="snackbar_files_deleted">Dateien gelöscht</string>
 
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -219,7 +219,7 @@
     <string name="symbol">SYMBOL</string>
     <string name="zapfdingbats">ZAPFDINGBATS</string>
     <string name="undefined">UNDEFINED</string>
-    <string name="delete_alert">¿Está seguro que quiere eliminar los archivos seleccionados?</string>
+    <string name="delete_alert_selected">¿Está seguro que quiere eliminar los archivos seleccionados?</string>
     <string name="sort_by_title">Ordenar por</string>
     <string name="selected_image">Imagen Seleccionada</string>
     <string name="arrow_up">Arrow Up</string>
@@ -424,4 +424,6 @@
     <string name="no_excel_file">Ningún archivo excel seleccionado</string>
     <string name="split_range_alert">Entered split range will create Selected PDF again!</string>
     <string name="reordering_pages_dialog">Reordenando tus páginas</string>
+    <string name="delete_alert_singular">¿Quieres eliminar el archivo seleccionado?</string>
+    <string name="snackbar_files_deleted">Archivos eliminados</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -174,7 +174,7 @@
     <string name="symbol">SYMBOL</string>
     <string name="zapfdingbats">ZAPFDINGBATS</string>
     <string name="undefined">NON DÉFINIT</string>
-    <string name="delete_alert">Voulez-vous supprimer tous les fichiers sélectionnés \?</string>
+    <string name="delete_alert_selected">Voulez-vous supprimer tous les fichiers sélectionnés \?</string>
     <string name="sort_by_title">Trier par</string>
     <string name="selected_image">Image sélectionnée</string>
     <string name="rearrange_images">Réorganiser les images</string>
@@ -411,4 +411,6 @@
 \n3. Fill the required information. Select OK. 
 \n4. New PDF with watermark will be created.</string>
     <string name="reordering_pages_dialog">Réorganiser vos pages...</string>
+    <string name="delete_alert_singular">Voulez-vous supprimer le fichier sélectionné?</string>
+    <string name="snackbar_files_deleted">Fichiers supprimés</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -220,7 +220,7 @@
     <string name="symbol">SYMBOL</string>
     <string name="zapfdingbats">ZAPFDINGBATS</string>
     <string name="undefined">UNDEFINED</string>
-    <string name="delete_alert">Do you want to delete all selected files?</string>
+    <string name="delete_alert_selected">Do you want to delete all selected files?</string>
     <string name="sort_by_title">Sort by</string>
     <string name="selected_image">Selected Image</string>
     <string name="arrow_up">Arrow Up</string>
@@ -423,4 +423,6 @@
     <string name="no_excel_file">Excelファイルが選択されていません</string>
     <string name="split_range_alert">Entered split range will create Selected PDF again!</string>
     <string name="reordering_pages_dialog">ページの並べ替え...</string>
+    <string name="delete_alert_singular">選択したファイルを削除しますか？</string>
+    <string name="snackbar_files_deleted">削除されたファイル</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -155,7 +155,7 @@
     <string name="default_page_size">По умолчанию ( %s )</string>
 
 
-    <string name="delete_alert">Удалить все выбранные файлы?</string>
+    <string name="delete_alert_selected">Удалить все выбранные файлы?</string>
     <string name="sort_by_title">Сортировка</string>
 
     <!-- Directory Strings -->
@@ -466,4 +466,6 @@
     <string name="no_excel_file">Файл Excel не выбран</string>
     <string name="split_range_alert">Entered split range will create Selected PDF again!</string>
     <string name="reordering_pages_dialog">Изменение порядка страниц...</string>
+    <string name="delete_alert_singular">Вы хотите удалить выбранный файл?</string>
+    <string name="snackbar_files_deleted">Файлы удалены</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,7 +226,7 @@
     <string name="master_password_changed">The password seems to be incorrect. May be, you have changed the master password.</string>
 
 
-    <string name="delete_alert">Do you want to delete all selected files?</string>
+    <string name="delete_alert_selected">Do you want to delete all selected files?</string>
     <string name="sort_by_title">Sort by</string>
 
     <!-- Directory Strings -->
@@ -528,8 +528,10 @@
     <!--file name suffix-->
     <string name="pdf_suffix" translatable="false">_pdf</string>
     <string name="reordering_pages_dialog">Reordering your pages...</string>
+    <string name="delete_alert_singular">Do you want to delete selected file?</string>
+    <string name="snackbar_files_deleted">Files Deleted</string>
 
-    <string-array name="faq_question_answers">
+  <string-array name="faq_question_answers">
         <item>What image file formats are supported?#####The software supports jpeg, jpg, tiff, gif, psd, bmp, eps, png, etc.</item>
         <item>Can I create a new text file with the software?#####No new text files can\'t be created. You can only convert already made text files to pdf.</item>
         <item>What is the maximum limit of images I can add to create a pdf file?#####There is no restriction to the number of images you desire to convert to pdf. You can include as many images as you desire.</item>


### PR DESCRIPTION
# Description
Deleting files using Action bar option showed confirmation dialog but didn't show a snackbar for undo while deleting single file didn't show confirmation dialog but showed snackbar for undo. 

Fixes #874
Deleting single and multiple file both show confirmation dialog and snackbar for undo.

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ x ] `./gradlew assembleDebug assembleRelease`
- [ x ] `./gradlew checkstyle`

# Checklist:
- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
