### PR TITLE
#865: Add builder instead of maintaining state in enhancer

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/Enhancers.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/Enhancers.java
@@ -3,6 +3,7 @@ package swati4star.createpdf.fragment.texttopdf;
 import android.app.Activity;
 
 import swati4star.createpdf.interfaces.Enhancer;
+import swati4star.createpdf.model.TextToPDFOptions;
 
 /**
  * The {@link Enhancers} represent a list of enhancers for the Text-to-PDF feature.
@@ -10,45 +11,53 @@ import swati4star.createpdf.interfaces.Enhancer;
 public enum Enhancers {
     FONT_COLOR {
         @Override
-        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view) {
-            return new PageColorEnhancer(activity);
+        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                             TextToPDFOptions.Builder builder) {
+            return new FontColorEnhancer(activity, builder);
         }
     },
     FONT_FAMILY {
         @Override
-        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view) {
-            return new FontFamilyEnhancer(activity, view);
+        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                             TextToPDFOptions.Builder builder) {
+            return new FontFamilyEnhancer(activity, view, builder);
         }
     },
     FONT_SIZE {
         @Override
-        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view) {
-            return new FontSizeEnhancer(activity, view);
+        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                             TextToPDFOptions.Builder builder) {
+            return new FontSizeEnhancer(activity, view, builder);
         }
     },
     PAGE_COLOR {
         @Override
-        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view) {
-            return new PageColorEnhancer(activity);
+        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                             TextToPDFOptions.Builder builder) {
+            return new PageColorEnhancer(activity, builder);
         }
     },
     PAGE_SIZE {
         @Override
-        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view) {
+        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                             TextToPDFOptions.Builder builder) {
             return new PageSizeEnhancer(activity);
         }
     },
     PASSWORD {
         @Override
-        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view) {
-            return new PasswordEnhancer(activity, view);
+        Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                             TextToPDFOptions.Builder builder) {
+            return new PasswordEnhancer(activity, view, builder);
         }
     };
 
     /**
      * @param activity The {@link Activity} context.
      * @param view The {@link TextToPdfContract.View} that needs the enhancement.
+     * @param builder The builder for {@link TextToPDFOptions}.
      * @return An instance of the {@link Enhancer}.
      */
-    abstract Enhancer getEnhancer(Activity activity, TextToPdfContract.View view);
+    abstract Enhancer getEnhancer(Activity activity, TextToPdfContract.View view,
+                                  TextToPDFOptions.Builder builder);
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/FontColorEnhancer.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/FontColorEnhancer.java
@@ -11,6 +11,7 @@ import com.github.danielnilsson9.colorpickerview.view.ColorPickerView;
 import swati4star.createpdf.R;
 import swati4star.createpdf.interfaces.Enhancer;
 import swati4star.createpdf.model.EnhancementOptionsEntity;
+import swati4star.createpdf.model.TextToPDFOptions;
 import swati4star.createpdf.preferences.TextToPdfPreferences;
 import swati4star.createpdf.util.ColorUtils;
 import swati4star.createpdf.util.StringUtils;
@@ -22,13 +23,14 @@ public class FontColorEnhancer implements Enhancer {
 
     private final Activity mActivity;
     private final EnhancementOptionsEntity mEnhancementOptionsEntity;
-    private int mFontColor;
     private final TextToPdfPreferences mPreferences;
+    private final TextToPDFOptions.Builder mBuilder;
 
-    FontColorEnhancer(@NonNull final Activity activity) {
+    FontColorEnhancer(@NonNull final Activity activity,
+                      @NonNull final TextToPDFOptions.Builder builder) {
         mActivity = activity;
         mPreferences = new TextToPdfPreferences(activity);
-        mFontColor = mPreferences.getFontColor();
+        mBuilder = builder;
         mEnhancementOptionsEntity =  new EnhancementOptionsEntity(
                 mActivity, R.drawable.ic_color, R.string.font_color);
     }
@@ -44,27 +46,24 @@ public class FontColorEnhancer implements Enhancer {
                     View view = dialog.getCustomView();
                     ColorPickerView colorPickerView = view.findViewById(R.id.color_picker);
                     CheckBox defaultCheckbox = view.findViewById(R.id.set_default);
-                    mFontColor = colorPickerView.getColor();
+                    final int fontcolor = colorPickerView.getColor();
                     final int pageColor = mPreferences.getPageColor();
-                    if (ColorUtils.getInstance().colorSimilarCheck(mFontColor, pageColor)) {
+                    if (ColorUtils.getInstance().colorSimilarCheck(fontcolor, pageColor)) {
                         StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_color_too_close);
                     }
                     if (defaultCheckbox.isChecked()) {
-                        mPreferences.setFontColor(mFontColor);
+                        mPreferences.setFontColor(fontcolor);
                     }
+                    mBuilder.setFontColor(fontcolor);
                 })
                 .build();
         ColorPickerView colorPickerView = materialDialog.getCustomView().findViewById(R.id.color_picker);
-        colorPickerView.setColor(mFontColor);
+        colorPickerView.setColor(mBuilder.getFontColor());
         materialDialog.show();
     }
 
     @Override
     public EnhancementOptionsEntity getEnhancementOptionsEntity() {
         return mEnhancementOptionsEntity;
-    }
-
-    int getFontColor() {
-        return mFontColor;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/FontFamilyEnhancer.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/FontFamilyEnhancer.java
@@ -13,6 +13,7 @@ import com.itextpdf.text.Font;
 import swati4star.createpdf.R;
 import swati4star.createpdf.interfaces.Enhancer;
 import swati4star.createpdf.model.EnhancementOptionsEntity;
+import swati4star.createpdf.model.TextToPDFOptions;
 import swati4star.createpdf.preferences.TextToPdfPreferences;
 
 /**
@@ -21,19 +22,21 @@ import swati4star.createpdf.preferences.TextToPdfPreferences;
 public class FontFamilyEnhancer implements Enhancer {
 
     private final Activity mActivity;
-    private Font.FontFamily mFontFamily;
     private EnhancementOptionsEntity mEnhancementOptionsEntity;
     private TextToPdfContract.View mView;
     private final TextToPdfPreferences mPreferences;
+    private final TextToPDFOptions.Builder mBuilder;
 
     FontFamilyEnhancer(@NonNull final Activity activity,
-                       @NonNull final TextToPdfContract.View view) {
+                       @NonNull final TextToPdfContract.View view,
+                       @NonNull final TextToPDFOptions.Builder builder) {
         mActivity = activity;
         mPreferences = new TextToPdfPreferences(activity);
-        mFontFamily = Font.FontFamily.valueOf(mPreferences.getFontFamily());
+        mBuilder = builder;
         mEnhancementOptionsEntity = new EnhancementOptionsEntity(
                 mActivity, R.drawable.ic_font_family_24dp,
-                String.format(mActivity.getString(R.string.default_font_family_text), mFontFamily.name()));
+                String.format(mActivity.getString(R.string.default_font_family_text),
+                        mBuilder.getFontFamily().name()));
         mView = view;
     }
     /**
@@ -54,7 +57,7 @@ public class FontFamilyEnhancer implements Enhancer {
                     int selectedId = radioGroup.getCheckedRadioButtonId();
                     RadioButton radioButton = view.findViewById(selectedId);
                     String fontFamily1 = radioButton.getText().toString();
-                    mFontFamily = Font.FontFamily.valueOf(fontFamily1);
+                    mBuilder.setFontFamily(Font.FontFamily.valueOf(fontFamily1));
                     final CheckBox cbSetDefault = view.findViewById(R.id.cbSetDefault);
                     if (cbSetDefault.isChecked()) {
                         mPreferences.setFontFamily(fontFamily1);
@@ -77,12 +80,8 @@ public class FontFamilyEnhancer implements Enhancer {
      * Displays font family in UI
      */
     private void showFontFamily() {
-        mEnhancementOptionsEntity.setName(mActivity.getString(R.string.font_family_text) + mFontFamily.name());
+        mEnhancementOptionsEntity.setName(mActivity.getString(R.string.font_family_text)
+                + mBuilder.getFontFamily().name());
         mView.updateView();
-
-    }
-
-    Font.FontFamily getFontFamily() {
-        return mFontFamily;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/FontSizeEnhancer.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/FontSizeEnhancer.java
@@ -10,6 +10,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import swati4star.createpdf.R;
 import swati4star.createpdf.interfaces.Enhancer;
 import swati4star.createpdf.model.EnhancementOptionsEntity;
+import swati4star.createpdf.model.TextToPDFOptions;
 import swati4star.createpdf.preferences.TextToPdfPreferences;
 import swati4star.createpdf.util.StringUtils;
 
@@ -20,21 +21,22 @@ public class FontSizeEnhancer implements Enhancer {
 
     private final Activity mActivity;
     private EnhancementOptionsEntity mEnhancementOptionsEntity;
-    private String mFontTitle;
-    private int mFontSize;
     private final TextToPdfContract.View mView;
     private final TextToPdfPreferences mPreferences;
+    private final TextToPDFOptions.Builder mBuilder;
 
     FontSizeEnhancer(@NonNull final Activity activity,
-                     @NonNull final TextToPdfContract.View view) {
+                     @NonNull final TextToPdfContract.View view,
+                     @NonNull final TextToPDFOptions.Builder builder) {
         mActivity = activity;
         mPreferences = new TextToPdfPreferences(activity);
-
-        mFontTitle = String.format(mActivity.getString(R.string.edit_font_size), mPreferences.getFontSize());
-        mFontSize = mPreferences.getFontSize();
+        mBuilder = builder;
+        mBuilder.setFontSizeTitle(
+                String.format(mActivity.getString(R.string.edit_font_size),
+                        mPreferences.getFontSize()));
         mEnhancementOptionsEntity = new EnhancementOptionsEntity(
                 mActivity.getResources().getDrawable(R.drawable.ic_font_black_24dp),
-                mFontTitle);
+                mBuilder.getFontSizeTitle());
         mView = view;
     }
 
@@ -44,7 +46,7 @@ public class FontSizeEnhancer implements Enhancer {
     @Override
     public void enhance() {
         new MaterialDialog.Builder(mActivity)
-                .title(mFontTitle)
+                .title(mBuilder.getFontSizeTitle())
                 .customView(R.layout.dialog_font_size, true)
                 .positiveText(R.string.ok)
                 .negativeText(R.string.cancel)
@@ -56,13 +58,13 @@ public class FontSizeEnhancer implements Enhancer {
                         if (check > 1000 || check < 0) {
                             StringUtils.getInstance().showSnackbar(mActivity, R.string.invalid_entry);
                         } else {
-                            mFontSize = check;
+                            mBuilder.setFontSize(check);
                             showFontSize();
                             StringUtils.getInstance().showSnackbar(mActivity, R.string.font_size_changed);
                             if (cbSetDefault.isChecked()) {
-                                mPreferences.setFontSize(mFontSize);
-                                mFontTitle = String.format(mActivity.getString(R.string.edit_font_size),
-                                        mPreferences.getFontSize());
+                                mPreferences.setFontSize(mBuilder.getFontSize());
+                                mBuilder.setFontSizeTitle(String.format(mActivity.getString(R.string.edit_font_size),
+                                        mPreferences.getFontSize()));
                             }
                         }
                     } catch (NumberFormatException e) {
@@ -82,11 +84,8 @@ public class FontSizeEnhancer implements Enhancer {
      */
     private void showFontSize() {
         mEnhancementOptionsEntity
-                .setName(String.format(mActivity.getString(R.string.font_size), String.valueOf(mFontSize)));
+                .setName(String.format(mActivity.getString(R.string.font_size),
+                        String.valueOf(mBuilder.getFontSize())));
         mView.updateView();
-    }
-
-    int getFontSize() {
-        return mFontSize;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/PageColorEnhancer.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/PageColorEnhancer.java
@@ -11,6 +11,7 @@ import com.github.danielnilsson9.colorpickerview.view.ColorPickerView;
 import swati4star.createpdf.R;
 import swati4star.createpdf.interfaces.Enhancer;
 import swati4star.createpdf.model.EnhancementOptionsEntity;
+import swati4star.createpdf.model.TextToPDFOptions;
 import swati4star.createpdf.preferences.TextToPdfPreferences;
 import swati4star.createpdf.util.ColorUtils;
 import swati4star.createpdf.util.StringUtils;
@@ -22,13 +23,14 @@ public class PageColorEnhancer implements Enhancer {
 
     private final Activity mActivity;
     private final EnhancementOptionsEntity mEnhancementOptionsEntity;
-    private int mPageColor;
     private final TextToPdfPreferences mPreferences;
+    private final TextToPDFOptions.Builder mBuilder;
 
-    PageColorEnhancer(@NonNull final Activity activity) {
+    PageColorEnhancer(@NonNull final Activity activity,
+                      @NonNull final TextToPDFOptions.Builder builder) {
         mActivity = activity;
         mPreferences = new TextToPdfPreferences(activity);
-        mPageColor = mPreferences.getPageColor();
+        mBuilder = builder;
         mEnhancementOptionsEntity = new EnhancementOptionsEntity(
                 mActivity, R.drawable.ic_page_color, R.string.page_color);
     }
@@ -44,27 +46,24 @@ public class PageColorEnhancer implements Enhancer {
                     View view = dialog.getCustomView();
                     ColorPickerView colorPickerView = view.findViewById(R.id.color_picker);
                     CheckBox defaultCheckbox = view.findViewById(R.id.set_default);
-                    mPageColor = colorPickerView.getColor();
+                    final int pageColor = colorPickerView.getColor();
                     final int fontColor = mPreferences.getFontColor();
-                    if (ColorUtils.getInstance().colorSimilarCheck(fontColor, mPageColor)) {
+                    if (ColorUtils.getInstance().colorSimilarCheck(fontColor, pageColor)) {
                         StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_color_too_close);
                     }
                     if (defaultCheckbox.isChecked()) {
-                        mPreferences.setPageColor(mPageColor);
+                        mPreferences.setPageColor(pageColor);
                     }
+                    mBuilder.setPageColor(pageColor);
                 })
                 .build();
         ColorPickerView colorPickerView = materialDialog.getCustomView().findViewById(R.id.color_picker);
-        colorPickerView.setColor(mPageColor);
+        colorPickerView.setColor(mBuilder.getPageColor());
         materialDialog.show();
     }
 
     @Override
     public EnhancementOptionsEntity getEnhancementOptionsEntity() {
         return mEnhancementOptionsEntity;
-    }
-
-    int getPageColor() {
-        return mPageColor;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/PasswordEnhancer.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/PasswordEnhancer.java
@@ -13,6 +13,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import swati4star.createpdf.R;
 import swati4star.createpdf.interfaces.Enhancer;
 import swati4star.createpdf.model.EnhancementOptionsEntity;
+import swati4star.createpdf.model.TextToPDFOptions;
 import swati4star.createpdf.util.DialogUtils;
 import swati4star.createpdf.util.StringUtils;
 
@@ -23,14 +24,15 @@ public class PasswordEnhancer implements Enhancer {
 
     private final Activity mActivity;
     private final EnhancementOptionsEntity mEnhancementOptionsEntity;
-    private String mPassword;
-    private boolean mPasswordProtected;
     private TextToPdfContract.View mView;
+    private final TextToPDFOptions.Builder mBuilder;
 
     PasswordEnhancer(@NonNull final Activity activity,
-                     @NonNull final TextToPdfContract.View view) {
+                     @NonNull final TextToPdfContract.View view,
+                     @NonNull final TextToPDFOptions.Builder builder) {
         mActivity = activity;
-        mPasswordProtected = false;
+        mBuilder = builder;
+        mBuilder.setPasswordProtected(false);
         mEnhancementOptionsEntity = new EnhancementOptionsEntity(
                 mActivity, R.drawable.baseline_enhanced_encryption_24, R.string.set_password);
         mView = view;
@@ -48,7 +50,7 @@ public class PasswordEnhancer implements Enhancer {
         final View positiveAction = dialog.getActionButton(DialogAction.POSITIVE);
         final View neutralAction = dialog.getActionButton(DialogAction.NEUTRAL);
         final EditText passwordInput = dialog.getCustomView().findViewById(R.id.password);
-        passwordInput.setText(mPassword);
+        passwordInput.setText(mBuilder.getPassword());
         passwordInput.addTextChangedListener(
                 new TextWatcher() {
                     @Override
@@ -69,18 +71,18 @@ public class PasswordEnhancer implements Enhancer {
             if (StringUtils.getInstance().isEmpty(passwordInput.getText())) {
                 StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_password_cannot_be_blank);
             } else {
-                mPassword = passwordInput.getText().toString();
-                mPasswordProtected = true;
+                mBuilder.setPassword(passwordInput.getText().toString());
+                mBuilder.setPasswordProtected(true);
                 onPasswordAdded();
                 dialog.dismiss();
             }
         });
 
-        if (StringUtils.getInstance().isNotEmpty(mPassword)) {
+        if (StringUtils.getInstance().isNotEmpty(mBuilder.getPassword())) {
             neutralAction.setOnClickListener(v -> {
-                mPassword = null;
+                mBuilder.setPassword(null);
                 onPasswordRemoved();
-                mPasswordProtected = false;
+                mBuilder.setPasswordProtected(false);
                 dialog.dismiss();
                 StringUtils.getInstance().showSnackbar(mActivity, R.string.password_remove);
             });
@@ -104,13 +106,5 @@ public class PasswordEnhancer implements Enhancer {
         mEnhancementOptionsEntity
                 .setImage(mActivity.getResources().getDrawable(R.drawable.baseline_enhanced_encryption_24));
         mView.updateView();
-    }
-
-    String getPassword() {
-        return mPassword;
-    }
-
-    boolean isPasswordProtected() {
-        return mPasswordProtected;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
@@ -72,6 +72,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
     private MorphButtonUtility mMorphButtonUtility;
     private String mPath;
     private List<Enhancer> mEnhancerList;
+    private TextToPDFOptions.Builder mBuilder;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -82,6 +83,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
         mMorphButtonUtility = new MorphButtonUtility(mActivity);
         ButterKnife.bind(this, rootView);
 
+        mBuilder = new TextToPDFOptions.Builder(getContext());
         addEnhancements();
         showEnhancementOptions();
         mMorphButtonUtility.morphToGrey(mCreateTextPdf, mMorphButtonUtility.integer());
@@ -92,7 +94,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
     private void addEnhancements() {
         mEnhancerList = new ArrayList<>();
         for (final Enhancers enhancer: Enhancers.values()) {
-            mEnhancerList.add(enhancer.getEnhancer(mActivity, this));
+            mEnhancerList.add(enhancer.getEnhancer(mActivity, this, mBuilder));
         }
     }
 
@@ -147,23 +149,12 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
      * @param mFilename name of file to be created.
      */
     private void createPdf(String mFilename) {
-
-        final FontSizeEnhancer fontSizeEnhancer = (FontSizeEnhancer) mEnhancerList.get(0);
-        final FontFamilyEnhancer fontFamilyEnhancer = (FontFamilyEnhancer) mEnhancerList.get(1);
-        final PasswordEnhancer passwordEnhancer = (PasswordEnhancer) mEnhancerList.get(3);
-        final FontColorEnhancer fontColorEnhancer = (FontColorEnhancer) mEnhancerList.get(4);
-        final PageColorEnhancer pageColorEnhancer = (PageColorEnhancer) mEnhancerList.get(5);
-
         mPath = mDirectoryUtils.getOrCreatePdfDirectory().getPath();
         mPath = mPath + "/" + mFilename + mActivity.getString(R.string.pdf_ext);
-        TextToPDFOptions options = new TextToPDFOptions(mFilename, PageSizeUtils.mPageSize,
-                passwordEnhancer.isPasswordProtected(),
-                passwordEnhancer.getPassword(),
-                mTextFileUri,
-                fontSizeEnhancer.getFontSize(),
-                fontFamilyEnhancer.getFontFamily(),
-                fontColorEnhancer.getFontColor(),
-                pageColorEnhancer.getPageColor());
+        TextToPDFOptions options = mBuilder.setFileName(mFilename)
+                .setPageSize(PageSizeUtils.mPageSize)
+                .setInFileUri(mTextFileUri)
+                .build();
         TextToPDFUtils fileUtil = new TextToPDFUtils(mActivity);
         new TextToPdfAsync(fileUtil, options, mFileExtension,
                 TextToPdfFragment.this).execute();
@@ -288,6 +279,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
         mCreateTextPdf.setEnabled(false);
         mTextFileUri = null;
         mButtonClicked = 0;
+        mBuilder = new TextToPDFOptions.Builder(getContext());
     }
 
     @Override

--- a/app/src/main/java/swati4star/createpdf/model/TextToPDFOptions.java
+++ b/app/src/main/java/swati4star/createpdf/model/TextToPDFOptions.java
@@ -1,8 +1,11 @@
 package swati4star.createpdf.model;
 
+import android.content.Context;
 import android.net.Uri;
 
 import com.itextpdf.text.Font;
+
+import swati4star.createpdf.preferences.TextToPdfPreferences;
 
 public class TextToPDFOptions extends PDFOptions {
     private final Uri mInFileUri;
@@ -34,5 +37,126 @@ public class TextToPDFOptions extends PDFOptions {
 
     public int getFontColor() {
         return mFontColor;
+    }
+
+    public static class Builder {
+
+        private String mFileName;
+        private String mPageSize;
+        private boolean mPasswordProtected;
+        private String mPassword;
+        private int mPageColor;
+        private Uri mInFileUri;
+        private int mFontSize;
+        private Font.FontFamily mFontFamily;
+        private int mFontColor;
+        private String mFontSizeTitle;
+
+        public Builder(Context context) {
+            final TextToPdfPreferences preferences = new TextToPdfPreferences(context);
+            mPageSize = preferences.getPageSize();
+            mPasswordProtected = false;
+            mFontColor = preferences.getFontColor();
+            mFontFamily = Font.FontFamily.valueOf(preferences.getFontFamily());
+            mFontSize = preferences.getFontSize();
+            mPageColor = preferences.getPageColor();
+        }
+
+        public String getFileName() {
+            return mFileName;
+        }
+
+        public Builder setFileName(String fileName) {
+            mFileName = fileName;
+            return this;
+        }
+
+        public String getPageSize() {
+            return mPageSize;
+        }
+
+        public Builder setPageSize(String pageSize) {
+            mPageSize = pageSize;
+            return this;
+        }
+
+        public boolean isPasswordProtected() {
+            return mPasswordProtected;
+        }
+
+        public Builder setPasswordProtected(boolean passwordProtected) {
+            mPasswordProtected = passwordProtected;
+            return this;
+        }
+
+        public String getPassword() {
+            return mPassword;
+        }
+
+        public Builder setPassword(String password) {
+            mPassword = password;
+            return this;
+        }
+
+        public int getPageColor() {
+            return mPageColor;
+        }
+
+        public Builder setPageColor(int pageColor) {
+            mPageColor = pageColor;
+            return this;
+        }
+
+        public Uri getInFileUri() {
+            return mInFileUri;
+        }
+
+        public Builder setInFileUri(Uri inFileUri) {
+            mInFileUri = inFileUri;
+            return this;
+        }
+
+        public int getFontSize() {
+            return mFontSize;
+        }
+
+        public Builder setFontSize(int fontSize) {
+            mFontSize = fontSize;
+            return this;
+        }
+
+        public Font.FontFamily getFontFamily() {
+            return mFontFamily;
+        }
+
+        public Builder setFontFamily(Font.FontFamily fontFamily) {
+            mFontFamily = fontFamily;
+            return this;
+        }
+
+        public int getFontColor() {
+            return mFontColor;
+        }
+
+        public Builder setFontColor(int fontColor) {
+            mFontColor = fontColor;
+            return this;
+        }
+
+        public String getFontSizeTitle() {
+            return mFontSizeTitle;
+        }
+
+        public Builder setFontSizeTitle(String fontSizeTitle) {
+            mFontSizeTitle = fontSizeTitle;
+            return this;
+        }
+
+        public TextToPDFOptions build() {
+            return new TextToPDFOptions(mFileName, mPageSize, mPasswordProtected,
+                    mPassword, mInFileUri, mFontSize, mFontFamily, mFontColor, mPageColor);
+        }
+
+
     }
 }


### PR DESCRIPTION
# Description

Adds a builder to the text-to-PDF enhancers instead of maintaining state in enhancers.

Fixes #(issue)

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
