### PR TITLE
Fix "No PDFs to Show" not disappearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is an easy to use Android app to convert images to PDF file!
 You can also join the Images To PDF Team on Slack [https://imagestopdf.slack.com/](https://imagestopdf.slack.com/) and chat with developers. Use [this link](https://join.slack.com/t/imagestopdf/shared_invite/zt-56xb0xf9-OaOUZ5lPyz2XkUKrJ1E57w) to join our slack team.
 
 ### Features 
-- Create PDF from multiple images from camera or galleryy
+- Create PDF from multiple images from camera or gallery
 - View your converted PDFs
   - Open, Rename, Delete, print, share files
   - Sort the files order based on a number of options

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is an easy to use Android app to convert images to PDF file!
 You can also join the Images To PDF Team on Slack [https://imagestopdf.slack.com/](https://imagestopdf.slack.com/) and chat with developers. Use [this link](https://join.slack.com/t/imagestopdf/shared_invite/enQtNDA2ODk1NDE3Mzk3LTUwNjllYzY5YWZkZDliY2FmNDhkNmM1NjIwZTc1YjU4NTgxNWI0ZDczMWQxMTEyZjA0M2Y5N2RlN2NiMWRjZGI) to join our slack team.
 
 ### Features 
-- Create PDF from multiple images from camera or gallery
+- Create PDF from multiple images from camera or galleryy
 - View your converted PDFs
   - Open, Rename, Delete, print, share files
   - Sort the files order based on a number of options

--- a/app/src/main/java/swati4star/createpdf/util/PopulateList.java
+++ b/app/src/main/java/swati4star/createpdf/util/PopulateList.java
@@ -69,7 +69,9 @@ public class PopulateList extends AsyncTask<Void, Void, Void> {
             mHandler.post(mEmptyStateChangeListener::showNoPermissionsView);
         else if (pdfFiles.size() == 0) {
             mHandler.post(mEmptyStateChangeListener::setEmptyStateVisible);
+            mHandler.post(() -> mAdapter.setData(null));
         } else {
+            mHandler.post(mEmptyStateChangeListener::setEmptyStateInvisible);
             FileSortUtils.getInstance().performSortOperation(mCurrentSortingIndex, pdfFiles);
             List<PDFFile> pdfFilesWithEncryptionStatus = getPdfFilesWithEncryptionStatus(pdfFiles);
             mHandler.post(mEmptyStateChangeListener::hideNoPermissionsView);


### PR DESCRIPTION
# Description
Added a call in the populateViewList method to set the empty stage message visibility to gone when the search has matches after not having matches.
Also, send an empty response for the setData method for the files in the list view to disappear when there are no matches

Fixes #899

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
