### PR TITLE
Fix merging pdf bug

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/MergeFilesFragment.java
@@ -28,6 +28,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.airbnb.lottie.LottieAnimationView;
 import com.dd.morphingbutton.MorphingButton;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
@@ -233,6 +234,11 @@ public class MergeFilesFragment extends Fragment implements MergeFilesAdapter.On
                         StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_name_not_blank);
                     } else {
                         if (!mFileUtils.isFileExist(input + getString(R.string.pdf_ext))) {
+                            File docsFolder = new File(mHomePath);
+                            if (!docsFolder.exists())
+                                docsFolder.mkdir();
+
+
                             new MergePdf(input.toString(), mHomePath, mPasswordProtected,
                                     mPassword, this, masterpwd).execute(pdfpaths);
                         } else {


### PR DESCRIPTION
FIX merging pdf bug

# Description

The issue because when app wanted to created merged pdf, App couldnt find the home directory (pdffile folder)
<img width="1393" alt="Screenshot 2020-05-21 at 9 36 16 AM" src="https://user-images.githubusercontent.com/11605562/82516051-66a30180-9b4c-11ea-9d57-102a2cc4c02d.png">


Fixes #881

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
1. Open app
2. select merge pdf feature
3. select pdf files
4. click merge button
5. put the name for merged pdf file
6. click ok.
Please describe the tests that you ran to verify your changes.
- [ x] `./gradlew assembleDebug assembleRelease`
- [x ] `./gradlew checkstyle`

# Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
