### PR TITLE
Making the emptyStateInvisible when there are more than 0 pdf files.

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/PopulateList.java
+++ b/app/src/main/java/swati4star/createpdf/util/PopulateList.java
@@ -72,6 +72,7 @@ public class PopulateList extends AsyncTask<Void, Void, Void> {
         } else {
             FileSortUtils.getInstance().performSortOperation(mCurrentSortingIndex, pdfFiles);
             List<PDFFile> pdfFilesWithEncryptionStatus = getPdfFilesWithEncryptionStatus(pdfFiles);
+            mHandler.post(mEmptyStateChangeListener::setEmptyStateInvisible);
             mHandler.post(mEmptyStateChangeListener::hideNoPermissionsView);
             mHandler.post(() -> mAdapter.setData(pdfFilesWithEncryptionStatus));
             mHandler.post(mEmptyStateChangeListener::filesPopulated);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
If there are any UI change, please include the screenshots also.

Fixes #899

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
