### PR TITLE
Refactor Watermark Utils

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/WatermarkUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/WatermarkUtils.java
@@ -43,7 +43,6 @@ public class WatermarkUtils {
     }
 
     public void setWatermark(String path, final DataSetChanged dataSetChanged) {
-
         final MaterialDialog mDialog = new MaterialDialog.Builder(mContext)
                 .title(R.string.add_watermark)
                 .customView(R.layout.add_watermark_dialog, true)
@@ -52,7 +51,6 @@ public class WatermarkUtils {
                 .build();
 
         final View mPositiveAction = mDialog.getActionButton(DialogAction.POSITIVE);
-
         this.mWatermark = new Watermark();
 
         final EditText watermarkTextInput = mDialog.getCustomView().findViewById(R.id.watermarkText);
@@ -70,6 +68,14 @@ public class WatermarkUtils {
         angleInput.setText("0");
         fontSizeInput.setText("50");
 
+        addTextChangedListener(watermarkTextInput, mPositiveAction);
+        addPositiveActionClickListener(mPositiveAction, watermarkTextInput, angleInput, fontFamilyInput, dataSetChanged, mDialog);
+
+        mDialog.show();
+    }
+
+
+    private void addTextChangedListener(EditText watermarkTextInput, View mPositiveAction) {
         watermarkTextInput.addTextChangedListener(
                 new TextWatcher() {
                     @Override
@@ -91,7 +97,9 @@ public class WatermarkUtils {
                         }
                     }
                 });
+    }
 
+    private void addPositiveActionClickListener(View mPositiveAction, EditText watermarkTextInput, EditText angleInput, Spinner fontFamilyInput, DataSetChanged dataSetChanged,  MaterialDialog mDialog) {
         mPositiveAction.setEnabled(false);
         mPositiveAction.setOnClickListener(v -> {
             try {
@@ -126,7 +134,6 @@ public class WatermarkUtils {
             }
             mDialog.dismiss();
         });
-        mDialog.show();
     }
 
     private String createWatermark(String path) throws IOException, DocumentException {


### PR DESCRIPTION
Remove code "Set Watermark" method into separate helper methods for clearer readability

# Description
This Pull request does some minor refactoring of "WatermarkUtils" that makes the method "SetWatermark" more readable. It takes 2 large code bulks used to set actions of certain elements and places them in separate helper methods.

Fixes #910

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
