### PR TITLE
Cognitive Complexity of checkIfBitmapIsWhite in FileUtils.java reduced to solve Swati4star#864

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/FileUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/FileUtils.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Environment;
@@ -367,20 +368,10 @@ public class FileUtils {
     private static boolean checkIfBitmapIsWhite(Bitmap bitmap) {
         if (bitmap == null)
             return true;
-
-        int w = bitmap.getWidth();
-        int h = bitmap.getHeight();
-
-        for (int i = 0; i < w; i++) {
-            for (int j = 0; j < h; j++) {
-                int pixel = bitmap.getPixel(i, j);
-                if (pixel != Color.WHITE) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
+        Bitmap whiteBitmap = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), bitmap.getConfig());
+        Canvas canvas = new Canvas(whiteBitmap);
+        canvas.drawColor(Color.WHITE);
+        return bitmap.sameAs(whiteBitmap);
     }
 
     /**


### PR DESCRIPTION
# Description

Earlier it was checking the bitmap pixel by pixel using nested for loop.
Now, i am creating another blank bitmap with same width, height and config.
then making the new bitmap white.
and then comparing the two.
using the command `bitmap.sameAs(whiteBitmap)`

#864 

## Type of change
Just put an x in the [] which are valid
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
