### PR TITLE
Added tests for getRoundBitmap() and toGrayscale() and moved ImageUtilsTest to androidTest

### DIFF
--- a/app/src/androidTest/java/swati4star/createpdf/util/ImageUtilsTest.java
+++ b/app/src/androidTest/java/swati4star/createpdf/util/ImageUtilsTest.java
@@ -1,13 +1,21 @@
 package swati4star.createpdf.util;
 
+
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.support.test.runner.AndroidJUnit4;
+
 import com.itextpdf.text.Rectangle;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@RunWith(AndroidJUnit4.class)
 public class ImageUtilsTest {
     private static final Rectangle NO_NORMAL_ERROR =
             new Rectangle(0.0f, 0.0f, 0.0f, 0.0f);
@@ -16,9 +24,15 @@ public class ImageUtilsTest {
     private static final Rectangle NO_LINE_ERROR =
             new Rectangle(0.0f, 0.0f, 0.0f, 0.0f);
 
+    ImageUtils imageUtils;
+
+    @Before
+    public void setUp() throws Exception {
+        imageUtils = ImageUtils.getInstance();
+    }
+
     @Test
     public void testCalculateFitSize() {
-        ImageUtils imageUtils = ImageUtils.getInstance();
 
         float testWidth = 8.0f;
         float testHeight = 12.0f;
@@ -59,4 +73,52 @@ public class ImageUtilsTest {
                 testDocumentSizeLine).getRight(), NO_LINE_ERROR.getRight());
 
     }
+
+    @Test
+    public void testgetRoundBitmap() {
+        int width = 500, height = 100;
+        Bitmap bitmap500x100 = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        bitmap500x100.eraseColor(Color.RED);
+        Bitmap actualBmp = imageUtils.getRoundBitmap(bitmap500x100);
+
+        int actualWidth = actualBmp.getWidth();
+        int actualHeight = actualBmp.getHeight();
+        assertEquals(100, actualHeight);
+        assertEquals(100, actualWidth);
+
+        int rgb = actualBmp.getPixel(50, 50);
+        String hexColor = String.format("#%06X", (0xFFFFFF & rgb));
+        assertEquals("#FF0000", hexColor);
+
+    }
+
+    @Test
+    public void testtoGrayscale() {
+        int width = 100, height = 100;
+        Bitmap bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        bmp.eraseColor(Color.RED);
+        Bitmap actualBmp = imageUtils.toGrayscale(bmp);
+        String actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        //Gray Of Red
+        assertEquals("#363636", actualColor);
+
+        bmp.eraseColor(Color.GREEN);
+        actualBmp = imageUtils.toGrayscale(bmp);
+        actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        //Gray Of Green
+        assertEquals("#B6B6B6", actualColor);
+
+        bmp.eraseColor(Color.BLUE);
+        actualBmp = imageUtils.toGrayscale(bmp);
+        actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        //Gray Of Blue
+        assertEquals("#121212", actualColor);
+
+        bmp.eraseColor(Color.GRAY);
+        actualBmp = imageUtils.toGrayscale(bmp);
+        actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        assertEquals(String.format("#%06X", (0xFFFFFF & Color.GRAY)), actualColor);
+
+    }
+
 }


### PR DESCRIPTION
Added tests for getRoundBitmap() and toGrayscale() and moved ImageUtilsTest to androidTest

# Description

ImageUtils have test for only one method. So Added more test methods. And moved this ImageUtilsTest to androidTest, Because android SDK elements can not be got when we run it as local junit test, so it should be in androidTest.

# How Has This Been Tested?

I manually ran the test, and execute this commands too
- ./gradlew assembleDebug assembleRelease 
- ./gradlew checkstyle

# Checklist:
- My code follows the style guidelines of this project -->Yes
-  I have performed a self-review of my own code -->Yes
-  I have commented my code, particularly in hard-to-understand areas -->Yes
-  I have made corresponding changes to the documentation -->Yes
-  My changes generate no new warnings -->Yes
