### PR TITLE
Optimize getRound bitmap

### DIFF
--- a/app/src/androidTest/java/swati4star/createpdf/util/ImageUtilsTest.java
+++ b/app/src/androidTest/java/swati4star/createpdf/util/ImageUtilsTest.java
@@ -1,13 +1,21 @@
 package swati4star.createpdf.util;
 
+
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.support.test.runner.AndroidJUnit4;
+
 import com.itextpdf.text.Rectangle;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@RunWith(AndroidJUnit4.class)
 public class ImageUtilsTest {
     private static final Rectangle NO_NORMAL_ERROR =
             new Rectangle(0.0f, 0.0f, 0.0f, 0.0f);
@@ -16,9 +24,15 @@ public class ImageUtilsTest {
     private static final Rectangle NO_LINE_ERROR =
             new Rectangle(0.0f, 0.0f, 0.0f, 0.0f);
 
+    ImageUtils imageUtils;
+
+    @Before
+    public void setUp() throws Exception {
+        imageUtils = ImageUtils.getInstance();
+    }
+
     @Test
     public void testCalculateFitSize() {
-        ImageUtils imageUtils = ImageUtils.getInstance();
 
         float testWidth = 8.0f;
         float testHeight = 12.0f;
@@ -59,4 +73,52 @@ public class ImageUtilsTest {
                 testDocumentSizeLine).getRight(), NO_LINE_ERROR.getRight());
 
     }
+
+    @Test
+    public void testgetRoundBitmap() {
+        int width = 500, height = 100;
+        Bitmap bitmap500x100 = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        bitmap500x100.eraseColor(Color.RED);
+        Bitmap actualBmp = imageUtils.getRoundBitmap(bitmap500x100);
+
+        int actualWidth = actualBmp.getWidth();
+        int actualHeight = actualBmp.getHeight();
+        assertEquals(100, actualHeight);
+        assertEquals(100, actualWidth);
+
+        int rgb = actualBmp.getPixel(50, 50);
+        String hexColor = String.format("#%06X", (0xFFFFFF & rgb));
+        assertEquals("#FF0000", hexColor);
+
+    }
+
+    @Test
+    public void testtoGrayscale() {
+        int width = 100, height = 100;
+        Bitmap bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        bmp.eraseColor(Color.RED);
+        Bitmap actualBmp = imageUtils.toGrayscale(bmp);
+        String actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        //Gray Of Red
+        assertEquals("#363636", actualColor);
+
+        bmp.eraseColor(Color.GREEN);
+        actualBmp = imageUtils.toGrayscale(bmp);
+        actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        //Gray Of Green
+        assertEquals("#B6B6B6", actualColor);
+
+        bmp.eraseColor(Color.BLUE);
+        actualBmp = imageUtils.toGrayscale(bmp);
+        actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        //Gray Of Blue
+        assertEquals("#121212", actualColor);
+
+        bmp.eraseColor(Color.GRAY);
+        actualBmp = imageUtils.toGrayscale(bmp);
+        actualColor = String.format("#%06X", (0xFFFFFF & actualBmp.getPixel(0, 0)));
+        assertEquals(String.format("#%06X", (0xFFFFFF & Color.GRAY)), actualColor);
+
+    }
+
 }

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -71,11 +71,9 @@ public class ImageUtils {
         Bitmap bitmap;
 
         if (bmp.getWidth() != radius || bmp.getHeight() != radius) {
-            float smallest = Math.min(bmp.getWidth(), bmp.getHeight());
-            float factor = smallest / radius;
             bitmap = Bitmap.createScaledBitmap(bmp,
-                    (int) (bmp.getWidth() / factor),
-                    (int) (bmp.getHeight() / factor), false);
+                    (int) (bmp.getWidth() / 1.0f),
+                    (int) (bmp.getHeight() / 1.0f), false);
         } else {
             bitmap = bmp;
         }
@@ -127,6 +125,7 @@ public class ImageUtils {
 
     /**
      * Calculate the inSampleSize value for given bitmap options & image dimensions
+     *
      * @param options - bitmap options
      * @return inSampleSize value
      * https://developer.android.com/topic/performance/graphics/load-bitmap.html#java
@@ -154,7 +153,6 @@ public class ImageUtils {
     }
 
 
-
     public void showImageScaleTypeDialog(Context context, Boolean saveValue) {
 
         SharedPreferences mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -162,22 +160,22 @@ public class ImageUtils {
                 R.string.image_scale_type);
         MaterialDialog materialDialog =
                 builder.customView(R.layout.image_scale_type_dialog, true)
-                .onPositive((dialog1, which) -> {
-                    View view = dialog1.getCustomView();
-                    RadioGroup radioGroup = view.findViewById(R.id.scale_type);
-                    int selectedId = radioGroup.getCheckedRadioButtonId();
-                    if (selectedId == R.id.aspect_ratio)
-                        mImageScaleType = IMAGE_SCALE_TYPE_ASPECT_RATIO;
-                    else
-                        mImageScaleType = IMAGE_SCALE_TYPE_STRETCH;
+                        .onPositive((dialog1, which) -> {
+                            View view = dialog1.getCustomView();
+                            RadioGroup radioGroup = view.findViewById(R.id.scale_type);
+                            int selectedId = radioGroup.getCheckedRadioButtonId();
+                            if (selectedId == R.id.aspect_ratio)
+                                mImageScaleType = IMAGE_SCALE_TYPE_ASPECT_RATIO;
+                            else
+                                mImageScaleType = IMAGE_SCALE_TYPE_STRETCH;
 
-                    CheckBox mSetAsDefault = view.findViewById(R.id.cbSetDefault);
-                    if (saveValue || mSetAsDefault.isChecked()) {
-                        SharedPreferences.Editor editor = mSharedPreferences.edit();
-                        editor.putString(Constants.DEFAULT_IMAGE_SCALE_TYPE_TEXT, mImageScaleType);
-                        editor.apply();
-                    }
-                }).build();
+                            CheckBox mSetAsDefault = view.findViewById(R.id.cbSetDefault);
+                            if (saveValue || mSetAsDefault.isChecked()) {
+                                SharedPreferences.Editor editor = mSharedPreferences.edit();
+                                editor.putString(Constants.DEFAULT_IMAGE_SCALE_TYPE_TEXT, mImageScaleType);
+                                editor.apply();
+                            }
+                        }).build();
         if (saveValue) {
             View customView = materialDialog.getCustomView();
             customView.findViewById(R.id.cbSetDefault).setVisibility(View.GONE);
@@ -187,6 +185,7 @@ public class ImageUtils {
 
     /**
      * convert a bitmap to gray scale and return it
+     *
      * @param bmpOriginal original bitmap which is converted to a new
      *                    grayscale bitmap
      */


### PR DESCRIPTION
# Description

As per current code in ImageUtils,
 
```
        int width = bmp.getWidth(), height = bmp.getHeight();
        int radius = Math.min(width, height); // set the smallest edge as radius.
        Bitmap bitmap;

        if (bmp.getWidth() != radius || bmp.getHeight() != radius) {
            float smallest = Math.min(bmp.getWidth(), bmp.getHeight());
            float factor = smallest / radius;
            bitmap = Bitmap.createScaledBitmap(bmp,
                    (int) (bmp.getWidth() / factor),
                    (int) (bmp.getHeight() / factor), false);
        } else {
            bitmap = bmp;
```

in this line, radius and smallest will always be same, so factor will always be 1.0f. [Please correct me incase i am wrong]

So just changed like this,

```
        if (bmp.getWidth() != radius || bmp.getHeight() != radius) {
            bitmap = Bitmap.createScaledBitmap(bmp,
                    (int) (bmp.getWidth() / 1.0f),
                    (int) (bmp.getHeight() / 1.0f), false);
        } else {
            bitmap = bmp;
        }
```

# Tested manually by running test. and executed these lines
- ./gradlew assembleDebug assembleRelease
- ./gradlew checkstyle

# Checklist:
- My code follows the style guidelines of this project-->Yes
- I have performed a self-review of my own code --> Yes
- I have commented my code, particularly in hard-to-understand areas-->Yes
- I have made corresponding changes to the documentation-->Yes
- My changes generate no new warnings-->Yes
