### PR TITLE
Unify perm response

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/AddImagesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/AddImagesFragment.java
@@ -3,7 +3,6 @@ package swati4star.createpdf.fragment;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetBehavior;
@@ -161,16 +160,11 @@ public class AddImagesFragment extends Fragment implements BottomSheetPopulate,
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (grantResults.length < 1)
-            return;
-        if (requestCode == REQUEST_PERMISSIONS_CODE) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-                selectImages();
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_permissions_given);
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, REQUEST_PERMISSIONS_CODE, () -> {
+                    mPermissionGranted = true;
+                    selectImages();
+                });
     }
 
     @OnClick(R.id.pdfCreate)

--- a/app/src/main/java/swati4star/createpdf/fragment/AddTextFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/AddTextFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;

--- a/app/src/main/java/swati4star/createpdf/fragment/AddTextFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/AddTextFragment.java
@@ -313,14 +313,10 @@ public class AddTextFragment extends Fragment implements MergeFilesAdapter.OnCli
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (grantResults.length < 1)
-            return;
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT, () -> {
+                    mPermissionGranted = true;
+                });
     }
 
     @Override

--- a/app/src/main/java/swati4star/createpdf/fragment/ExceltoPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ExceltoPdfFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -208,16 +207,11 @@ public class ExceltoPdfFragment extends Fragment implements MergeFilesAdapter.On
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (grantResults.length < 1)
-            return;
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-                openExcelToPdf();
-                mStringUtils.showSnackbar(mActivity, R.string.snackbar_permissions_given);
-            } else
-                mStringUtils.showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT, () -> {
+                    mPermissionGranted = true;
+                    openExcelToPdf();
+                });
     }
 
     private void processUri() {

--- a/app/src/main/java/swati4star/createpdf/fragment/ExtractTextFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ExtractTextFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;

--- a/app/src/main/java/swati4star/createpdf/fragment/ExtractTextFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ExtractTextFragment.java
@@ -164,16 +164,11 @@ public class ExtractTextFragment extends Fragment implements MergeFilesAdapter.O
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (grantResults.length < 1)
-            return;
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-                openExtractText();
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_permissions_given);
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT, () -> {
+                    mPermissionGranted = true;
+                    openExtractText();
+                });
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ImageToPdfFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -301,17 +300,11 @@ public class ImageToPdfFragment extends Fragment implements OnItemClickListener,
                                            @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
 
-        if (grantResults.length < 1)
-            return;
-
-        if (requestCode == REQUEST_PERMISSIONS_CODE) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-                selectImages();
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_permissions_given);
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, REQUEST_PERMISSIONS_CODE, () -> {
+                    mPermissionGranted = true;
+                    selectImages();
+                });
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -3,7 +3,6 @@ package swati4star.createpdf.fragment;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;

--- a/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ViewFilesFragment.java
@@ -323,18 +323,8 @@ public class ViewFilesFragment extends Fragment
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
-
-        if (grantResults.length < 1) {
-            StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-            return;
-        }
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_permissions_given);
-                onRefresh();
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT, this::onRefresh);
     }
 
     @Override

--- a/app/src/main/java/swati4star/createpdf/fragment/ZipToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ZipToPdfFragment.java
@@ -3,7 +3,6 @@ package swati4star.createpdf.fragment;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -24,7 +23,6 @@ import swati4star.createpdf.R;
 import swati4star.createpdf.util.PermissionsUtils;
 import swati4star.createpdf.util.RealPathUtil;
 import swati4star.createpdf.util.ResultUtils;
-import swati4star.createpdf.util.StringUtils;
 import swati4star.createpdf.util.ZipToPdf;
 
 import static swati4star.createpdf.util.Constants.READ_WRITE_PERMISSIONS;

--- a/app/src/main/java/swati4star/createpdf/fragment/ZipToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/ZipToPdfFragment.java
@@ -104,14 +104,10 @@ public class ZipToPdfFragment extends Fragment {
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (grantResults.length < 1)
-            return;
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-                showFileChooser();
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT, () -> {
+                    mPermissionGranted = true;
+                    showFileChooser();
+                });
     }
 }

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
@@ -3,7 +3,6 @@ package swati4star.createpdf.fragment.texttopdf;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -233,16 +232,11 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (grantResults.length < 1)
-            return;
-        if (requestCode == PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT) {
-            if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                mPermissionGranted = true;
-                selectTextFile();
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_permissions_given);
-            } else
-                StringUtils.getInstance().showSnackbar(mActivity, R.string.snackbar_insufficient_permissions);
-        }
+        PermissionsUtils.getInstance().handleRequestPermissionsResult(mActivity, grantResults,
+                requestCode, PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE_RESULT, () -> {
+                    mPermissionGranted = true;
+                    selectTextFile();
+                });
     }
 
     private void getRuntimePermissions() {

--- a/app/src/main/java/swati4star/createpdf/util/PermissionsUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/PermissionsUtils.java
@@ -10,6 +10,8 @@ import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 
+import swati4star.createpdf.R;
+
 /**
  * !! IMPORTANT !!
  * permission arrays are defined in Constants.java file. we have two types of permissions:
@@ -78,5 +80,28 @@ public class PermissionsUtils {
         } else {
             return ((Fragment) context).requireActivity();
         }
+    }
+
+    /**
+     * Handle a RequestPermissionResult by checking if the first permission is granted
+     * and executing a Runnable when permission is granted
+     * @param grantResults the GrantResults Array
+     * @param requestCode
+     * @param expectedRequest
+     * @param whenSuccessful the Runnable to call when permission is granted
+     */
+    public void handleRequestPermissionsResult(Activity context, @NonNull int[] grantResults,
+                                               int requestCode, int expectedRequest, @NonNull Runnable whenSuccessful) {
+        if (requestCode != expectedRequest)
+            return;
+        if (grantResults.length < 1) {
+            StringUtils.getInstance().showSnackbar(context, R.string.snackbar_insufficient_permissions);
+            return;
+        }
+        if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            whenSuccessful.run();
+            StringUtils.getInstance().showSnackbar(context, R.string.snackbar_permissions_given);
+        } else
+            StringUtils.getInstance().showSnackbar(context, R.string.snackbar_insufficient_permissions);
     }
 }


### PR DESCRIPTION
# Description

CodeClimate showed a lot of duplicate code for handling onRequestPermissionsResult. This PR unifies the duplicate code to the PermissionsUtils class.

Helps the Code climate in #898 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
