### PR TITLE
Fix:#955 different locations of files is now supported in Add Text under Enhance Pdf section

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/AddTextFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/AddTextFragment.java
@@ -73,9 +73,9 @@ import static swati4star.createpdf.util.Constants.pdfExtension;
 public class AddTextFragment extends Fragment implements MergeFilesAdapter.OnClickListener,
         BottomSheetPopulate, OnBackPressedInterface, OnItemClickListener {
     private Activity mActivity;
-    private String mPdfpath;
+    private static String mPdfpath;
     private String mFontTitle;
-    private String mTextPath;
+    private static String mTextPath;
     private FileUtils mFileUtils;
     private MorphButtonUtility mMorphButtonUtility;
     private BottomSheetUtils mBottomSheetUtils;
@@ -216,13 +216,13 @@ public class AddTextFragment extends Fragment implements MergeFilesAdapter.OnCli
         if (requestCode == INTENT_REQUEST_PICK_PDF_FILE_CODE) {
             mPdfpath = RealPathUtil.getInstance().getRealPath(getContext(), data.getData());
             StringUtils.getInstance().showSnackbar(mActivity, getResources().getString(R.string.snackbar_pdfselected));
-            return;
         }
         if (requestCode == INTENT_REQUEST_PICK_TEXT_FILE_CODE) {
             mTextPath = RealPathUtil.getInstance().getRealPath(getContext(), data.getData());
             StringUtils.getInstance().showSnackbar(mActivity, getResources().getString(R.string.snackbar_txtselected));
         }
-        setTextAndActivateButtons(mPdfpath, mTextPath);
+        if (mPdfpath != null && mTextPath != null)
+            setTextAndActivateButtons(mPdfpath, mTextPath);
     }
 
     private void setTextAndActivateButtons(String pdfPath, String textPath) {


### PR DESCRIPTION
# Description
The PR enables to create a pdf with different locations for pdf and text file selected under Add Text, Enhance pdf section.

Fixes #955 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please check the gif below:
![fix955](https://user-images.githubusercontent.com/34762451/95662624-df374880-0b55-11eb-8123-34558a811652.gif)

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
