### PR TITLE
908 crash 3 context leakage

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
@@ -82,7 +82,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
         mMorphButtonUtility = new MorphButtonUtility(mActivity);
         ButterKnife.bind(this, rootView);
 
-        mBuilder = new TextToPDFOptions.Builder(mActivity);
+        mBuilder = new TextToPDFOptions.Builder(getContext());
         addEnhancements();
         showEnhancementOptions();
         mMorphButtonUtility.morphToGrey(mCreateTextPdf, mMorphButtonUtility.integer());
@@ -273,7 +273,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
         mCreateTextPdf.setEnabled(false);
         mTextFileUri = null;
         mButtonClicked = 0;
-        mBuilder = new TextToPDFOptions.Builder(mActivity);
+        mBuilder = new TextToPDFOptions.Builder(getContext());
     }
 
     @Override

--- a/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/texttopdf/TextToPdfFragment.java
@@ -82,7 +82,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
         mMorphButtonUtility = new MorphButtonUtility(mActivity);
         ButterKnife.bind(this, rootView);
 
-        mBuilder = new TextToPDFOptions.Builder(getContext());
+        mBuilder = new TextToPDFOptions.Builder(mActivity);
         addEnhancements();
         showEnhancementOptions();
         mMorphButtonUtility.morphToGrey(mCreateTextPdf, mMorphButtonUtility.integer());
@@ -273,7 +273,7 @@ public class TextToPdfFragment extends Fragment implements OnItemClickListener,
         mCreateTextPdf.setEnabled(false);
         mTextFileUri = null;
         mButtonClicked = 0;
-        mBuilder = new TextToPDFOptions.Builder(getContext());
+        mBuilder = new TextToPDFOptions.Builder(mActivity);
     }
 
     @Override

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 04 15:31:11 EST 2021
+#Tue Oct 06 17:49:52 BRT 2020
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 06 17:49:52 BRT 2020
+#Mon Jan 04 15:31:11 EST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
# Description

It looks like context leakage could occur in TextToPdfFragment.java. I noticed getContext() is being used to get the context for TextToPDFOptions.Builder(getContext()).

getContext() may return null if the fragment is not attached to the activity. Since we already have mActivity which is a context coming as part of onAttach, we can use that.

Fixes #(908-Crash 3)

#908 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assemble`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
