### PR TITLE
Fixed the blocked texts and swiper on the 'view files' page

### DIFF
--- a/app/src/main/res/layout/fragment_view_files.xml
+++ b/app/src/main/res/layout/fragment_view_files.xml
@@ -8,6 +8,63 @@
     tools:context=".fragment.ImageToPdfFragment">
 
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/emptyStatusView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/emptyBackgroundImage"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:contentDescription="@string/empty_image_description"
+            android:src="@drawable/circle"
+            app:layout_constraintBottom_toBottomOf="@+id/getStarted"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.6"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0" />
+
+        <TextView
+            android:id="@+id/emptyTextOverBgImage"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/no_pdf"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@+id/emptyBackgroundImage"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/emptyBackgroundImage"
+            app:layout_constraintVertical_bias="0.7" />
+
+        <Button
+            android:id="@+id/getStarted"
+            style="@style/MorphingButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="10dp"
+            android:text="@string/get_started"
+            android:textSize="18sp"
+            app:layout_constraintBottom_toBottomOf="@+id/emptyStatusView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/emptyTagLine" />
+
+        <TextView
+            android:id="@+id/emptyTagLine"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_files_text"
+            app:layout_constraintBottom_toTopOf="@+id/getStarted"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/emptyBackgroundImage" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe"
         android:layout_width="match_parent"
@@ -29,67 +86,6 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/emptyStatusView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone">
-
-        <ImageView
-            android:id="@+id/emptyBackgroundImage"
-            android:layout_width="0dp"
-            android:layout_height="401dp"
-            android:contentDescription="@string/empty_image_description"
-            android:src="@drawable/circle"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/emptyTextOverBgImage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="245dp"
-            android:text="@string/no_pdf"
-            android:textSize="22sp"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="@+id/emptyBackgroundImage"
-            app:layout_constraintStart_toStartOf="@+id/emptyBackgroundImage"
-            app:layout_constraintTop_toTopOf="@+id/emptyBackgroundImage" />
-
-        <Button
-            android:id="@+id/getStarted"
-            style="@style/MorphingButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="150dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="45dp"
-            android:padding="10dp"
-            android:text="@string/get_started"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/emptyBackgroundImage"
-            app:layout_constraintTop_toBottomOf="@+id/emptyTextOverBgImage" />
-
-        <TextView
-            android:id="@+id/emptyTagLine"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="140dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
-            android:text="@string/view_files_text"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@+id/emptyBackgroundImage"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/getStarted" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <RelativeLayout
         android:id="@+id/no_permissions_view"
@@ -111,8 +107,8 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
             android:layout_alignParentStart="true"
+            android:layout_alignParentBottom="true"
             android:layout_marginBottom="200dp"
             android:gravity="center"
             android:text="@string/no_permissions"


### PR DESCRIPTION
# Description

Dear developer:

Hello! I am the creator of issue #1019, and I have fixed the blocked texts and swiper on the 'view files' page to make it more responsive. I would appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

:)

Fixes #1019 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I test this code on my Pixel 2. Configurations follow #1019. Here is the screenshot after my changes.

<img src="https://user-images.githubusercontent.com/25502419/130071789-9ceda83f-62f8-431e-a31c-bfa2daf79c4e.png" alt="copy" width="250"/>

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
