### PR TITLE
'Help' Tab bug fix #1034

### DIFF
--- a/app/src/main/res/layout/fragment_step_create_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_create_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_excel_to_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_excel_to_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_extract_images.xml
+++ b/app/src/main/res/layout/fragment_step_extract_images.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_merge_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_merge_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_qrcode_to_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_qrcode_to_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_remove_pages.xml
+++ b/app/src/main/res/layout/fragment_step_remove_pages.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_reorder_pages.xml
+++ b/app/src/main/res/layout/fragment_step_reorder_pages.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_text_to_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_text_to_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_view_file.xml
+++ b/app/src/main/res/layout/fragment_step_view_file.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"


### PR DESCRIPTION
# Description

I fixed a bug where text is not visible in the Help tab when applying the Dark or Black theme. (issue #1034 )
I would appreciate it if you could kindly revise my code and leave me some advice.
Thank you!

before 
![image](https://user-images.githubusercontent.com/67865411/143768951-748ba5b6-f122-43f7-bb3a-a7c8d88f41a7.png)

after
![image](https://user-images.githubusercontent.com/67865411/143768964-5b3e2103-0ac5-44c6-a069-88c87ac20a2b.png)

and Other 8 pages on 'Help' tap.

Fixes #1034 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease` 
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
