### PR TITLE
Bug fix on History tap

### DIFF
--- a/app/src/main/res/layout/layout_item_history.xml
+++ b/app/src/main/res/layout/layout_item_history.xml
@@ -6,7 +6,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="76dp"
         android:baselineAligned="false"
         android:orientation="horizontal"
         android:weightSum="7">


### PR DESCRIPTION
# Description

Increase the height of the 'History' layout and fix the corrupt text on 'History'.
Before
![image](https://user-images.githubusercontent.com/70866410/144006757-65286525-f5b7-4600-8063-20be13b93165.png)

After
![image](https://user-images.githubusercontent.com/70866410/144006954-ebbe6133-915d-4d82-a484-d290a439208a.png)



Fixes #(issue)

## Type of change
Just put an x in the [] which are valid.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [X] `./gradlew assembleDebug assembleRelease`
- [X] `./gradlew checkstyle`

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
