### PR TITLE
Fixed Split PDF strings.xml

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,7 +396,7 @@
     <!-- Split PDF -->
     <string name="split_pdf">Split PDF</string>
     <string name="split_success">The selected PDF was split successfully. It was split into %1$d PDF(s)</string>
-    <string name="split_info">The PDF will be split into multiple PDFs.Format example: 1&#8211;5,6&#8211;7,8,9</string>
+    <string name="split_info">The PDF will be split into multiple PDFs.\nFormat example: 1&#8211;5, 6&#8211;7, 8, 9</string>
     <string name="error_page_number">Invalid page number</string>
     <string name="error_page_range">Invalid range input</string>
     <string name="error_invalid_input">Invalid input</string>


### PR DESCRIPTION
# Description

I fixed the string (string name="split_info") in the split PDF page.

before 
![image](https://user-images.githubusercontent.com/67865411/144090494-526f461f-e617-4f3d-91ee-86d8a5ea4d61.png)

after 
![image](https://user-images.githubusercontent.com/67865411/144090548-8a919e76-ba52-4ad4-bbc5-6003d122e67d.png)

Thank you!

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
