### PR TITLE
Bug fix on 'Help' tap

### DIFF
--- a/app/src/main/res/layout/fragment_step_create_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_create_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_excel_to_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_excel_to_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_extract_images.xml
+++ b/app/src/main/res/layout/fragment_step_extract_images.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_merge_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_merge_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_qrcode_to_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_qrcode_to_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_remove_pages.xml
+++ b/app/src/main/res/layout/fragment_step_remove_pages.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_reorder_pages.xml
+++ b/app/src/main/res/layout/fragment_step_reorder_pages.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_text_to_pdf.xml
+++ b/app/src/main/res/layout/fragment_step_text_to_pdf.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_step_view_file.xml
+++ b/app/src/main/res/layout/fragment_step_view_file.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/mb_white">
+    android:layout_height="match_parent">
 
     <ImageView
         android:layout_width="match_parent"


### PR DESCRIPTION
# Description

I fixed a bug where text is not visible in the Help tab when applying the Dark or Black theme. (issue #1034 )
I would appreciate it if you could kindly revise my code and leave me some advice.
Thank you!

before 
![image](https://user-images.githubusercontent.com/67865411/144280066-28b2a3d5-348d-4774-83db-7bc4e3d2d13b.png)

after
![image](https://user-images.githubusercontent.com/67865411/144280082-c0c85513-195b-414a-8cfc-047ef3737d5b.png)


Fixes #1034 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
