### PR TITLE
fix 1059 Converting large image to pdf causes app to crash

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
@@ -135,7 +135,7 @@ public class CreatePdf extends AsyncTask<String, String, String> {
                 if (StringUtils.getInstance().isNotEmpty(mQualityString)) {
                     quality = Integer.parseInt(mQualityString);
                 }
-                Image image = Image.getInstance(mImagesUri.get(i));
+                Image image = Image.getInstance(ImageUtils.stringPathToByteArray(mImagesUri.get(i)));
                 // compressionLevel is a value between 0 (best speed) and 9 (best compression)
                 double qualityMod = quality * 0.09;
                 image.setCompressionLevel((int) qualityMod);

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -28,6 +28,7 @@ import com.zhihu.matisse.MimeType;
 import com.zhihu.matisse.engine.impl.PicassoEngine;
 import com.zhihu.matisse.internal.entity.CaptureStrategy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 
@@ -214,6 +215,30 @@ public class ImageUtils {
         c.drawBitmap(bmpOriginal, 0, 0, paint);
         return bmpGrayscale;
     }
+
+
+    /**
+     * Convert string path to ByteArray and compress image in the procedure
+     *
+     * @param path    - name of the file
+     */
+    public static byte[] stringPathToByteArray(String path) {
+        final BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        BitmapFactory.decodeFile(path, options);
+
+        int reqHeight = 3840;
+        int reqWidth = 2180;
+        options.inSampleSize = Math.max(options.outHeight / reqHeight, options.outWidth / reqWidth);
+        options.inSampleSize = Math.max(options.inSampleSize, 1);
+
+        options.inJustDecodeBounds = false;
+        Bitmap bitmap = BitmapFactory.decodeFile(path, options);
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, byteStream);
+        return byteStream.toByteArray();
+    }
+
 
     /**
      * Saves bitmap to external storage


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
If there are any UI change, please include the screenshots also.

Created a new method in ImageUtils called pathToByteStream and compress the image in the method. Then, use the byte stream to get itext.Image.

Fixes #1059

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
