### PR TITLE
Fix issue#1056 #1061

### DIFF
--- a/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
@@ -10,6 +10,10 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.ArrayList;
 
 import butterknife.BindView;
@@ -46,10 +50,102 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
 
     @Override
     public void onBindViewHolder(@NonNull ViewMergeFilesHolder holder, int position) {
-        boolean isEncrypted = mPDFUtils.isPDFEncrypted(mFilePaths.get(position));
-        holder.mFileName.setText(FileUtils.getFileName(mFilePaths.get(position)));
-        holder.mEncryptionImage.setVisibility(isEncrypted ? View.VISIBLE : View.INVISIBLE);
+        boolean isPdfFile = isPdfFile(mFilePaths.get(position));
+        if (isPdfFile) {
+            boolean isEncrypted = mPDFUtils.isPDFEncrypted(mFilePaths.get(position));
+            holder.mFileName.setText(FileUtils.getFileName(mFilePaths.get(position)));
+            holder.mEncryptionImage.setVisibility(isEncrypted ? View.VISIBLE : View.INVISIBLE);
+        }
+    }
 
+    /**
+     * check whether the file is a real pdf file or not (whether the file has the header of pdf file)
+     */
+    public static boolean isPdfFile(String filePath) {
+        String header = getFileHeader(filePath);
+        String end = getLastLine(filePath);
+        end = bytesToHexString(end.getBytes());
+        // '%PDF-1.4 in HEX is '255044462D312E'
+        // '%PDF' in HEX is '25504446'
+        // '%%EOF' in HEX is '2525454F46'
+        return header.startsWith("25504446") && end.startsWith("2525454F46");
+    }
+
+    public static String getFileHeader(String filePath) {
+        FileInputStream is = null;
+
+        String value = "";
+        try {
+            is = new FileInputStream(filePath);
+            byte[] b = new byte[20];
+            is.read(b, 0, b.length);
+            value = bytesToHexString(b);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (null != is) {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return value;
+    }
+
+    private static String bytesToHexString(byte[] src) {
+        StringBuilder builder = new StringBuilder();
+        if (src == null || src.length <= 0) {
+            return null;
+        }
+        String hv;
+        for (byte b : src) {
+            // Returns a string representation of an integer parameter in hexadecimal (Radix 16)
+            // unsigned integer form and converts it to uppercase
+            hv = Integer.toHexString(b & 0xFF).toUpperCase();
+            if (hv.length() < 2) {
+                builder.append(0);
+            }
+            builder.append(hv);
+        }
+        return builder.toString();
+    }
+
+    public static String getLastLine(String filePath) {
+        File file = new File(filePath);
+        // Store results
+        StringBuilder builder = new StringBuilder();
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+            // The pointer position starts at 0, so the maximum length is length-1
+            long fileLastPointer = randomAccessFile.length() - 1;
+            // Read file from back to front
+            for (long filePointer = fileLastPointer; filePointer != -1; filePointer--) {
+                // Move pointer to
+                randomAccessFile.seek(filePointer);
+                int readByte = randomAccessFile.readByte();
+                if (0xA == readByte) {
+                    //  LF='\n'=0x0A change line
+                    if (filePointer == fileLastPointer) {
+                        // If it is the last line feed, filter it out
+                        continue;
+                    }
+                    break;
+                }
+                if (0xD == readByte) {
+                    //  CR ='\r'=0x0D enter
+                    if (filePointer == fileLastPointer - 1) {
+                        // If it is the last carriage return, it is also filtered out
+                        continue;
+                    }
+                    break;
+                }
+                builder.append((char) readByte);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return builder.reverse().toString();
     }
 
     @Override

--- a/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
@@ -50,8 +50,8 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
 
     @Override
     public void onBindViewHolder(@NonNull ViewMergeFilesHolder holder, int position) {
-        boolean isInPdfEncodingFormat = isPdfFile(mFilePaths.get(position));
-        if (isInPdfEncodingFormat) {
+        boolean isPdfFile = isPdfFile(mFilePaths.get(position));
+        if (isPdfFile) {
             boolean isEncrypted = mPDFUtils.isPDFEncrypted(mFilePaths.get(position));
             holder.mFileName.setText(FileUtils.getFileName(mFilePaths.get(position)));
             holder.mEncryptionImage.setVisibility(isEncrypted ? View.VISIBLE : View.INVISIBLE);
@@ -59,7 +59,7 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
     }
 
     /**
-     * check whether the file is a real pdf file or not (whether the file has the header(%PDF) and the end(%%EOF))
+     * check whether the file is a real pdf file or not (whether the file has the header of pdf file)
      */
     public static boolean isPdfFile(String filePath) {
         String header = getFileHeader(filePath);
@@ -121,16 +121,24 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
             long fileLastPointer = randomAccessFile.length() - 1;
             // Read file from back to front
             for (long filePointer = fileLastPointer; filePointer != -1; filePointer--) {
-                // Move pointer
+                // Move pointer to
                 randomAccessFile.seek(filePointer);
                 int readByte = randomAccessFile.readByte();
-                if (0xA == readByte && filePointer == fileLastPointer) {
-                    //  LF='\n'=0x0A change line， If it is the last line feed, filter it out
-                    continue;
+                if (0xA == readByte) {
+                    //  LF='\n'=0x0A change line
+                    if (filePointer == fileLastPointer) {
+                        // If it is the last line feed, filter it out
+                        continue;
+                    }
+                    break;
                 }
-                if (0xD == readByte && filePointer == fileLastPointer - 1) {
-                    //  CR ='\r'=0x0D enter， If it is the last carriage return, it is also filtered out
-                    continue;
+                if (0xD == readByte) {
+                    //  CR ='\r'=0x0D enter
+                    if (filePointer == fileLastPointer - 1) {
+                        // If it is the last carriage return, it is also filtered out
+                        continue;
+                    }
+                    break;
                 }
                 builder.append((char) readByte);
             }

--- a/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
@@ -124,21 +124,13 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
                 // Move pointer
                 randomAccessFile.seek(filePointer);
                 int readByte = randomAccessFile.readByte();
-                if (0xA == readByte) {
-                    //  LF='\n'=0x0A change line
-                    if (filePointer == fileLastPointer) {
-                        // If it is the last line feed, filter it out
-                        continue;
-                    }
-                    break;
+                if (0xA == readByte && filePointer == fileLastPointer) {
+                    //  LF='\n'=0x0A change line， If it is the last line feed, filter it out
+                    continue;
                 }
-                if (0xD == readByte) {
-                    //  CR ='\r'=0x0D enter
-                    if (filePointer == fileLastPointer - 1) {
-                        // If it is the last carriage return, it is also filtered out
-                        continue;
-                    }
-                    break;
+                if (0xD == readByte && filePointer == fileLastPointer - 1) {
+                    //  CR ='\r'=0x0D enter， If it is the last carriage return, it is also filtered out
+                    continue;
                 }
                 builder.append((char) readByte);
             }

--- a/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
@@ -50,8 +50,8 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
 
     @Override
     public void onBindViewHolder(@NonNull ViewMergeFilesHolder holder, int position) {
-        boolean isPdfFile = isPdfFile(mFilePaths.get(position));
-        if (isPdfFile) {
+        boolean isInPdfEncodingFormat = isPdfFile(mFilePaths.get(position));
+        if (isInPdfEncodingFormat) {
             boolean isEncrypted = mPDFUtils.isPDFEncrypted(mFilePaths.get(position));
             holder.mFileName.setText(FileUtils.getFileName(mFilePaths.get(position)));
             holder.mEncryptionImage.setVisibility(isEncrypted ? View.VISIBLE : View.INVISIBLE);
@@ -59,7 +59,7 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
     }
 
     /**
-     * check whether the file is a real pdf file or not (whether the file has the header of pdf file)
+     * check whether the file is a real pdf file or not (whether the file has the header(%PDF) and the end(%%EOF))
      */
     public static boolean isPdfFile(String filePath) {
         String header = getFileHeader(filePath);
@@ -121,7 +121,7 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
             long fileLastPointer = randomAccessFile.length() - 1;
             // Read file from back to front
             for (long filePointer = fileLastPointer; filePointer != -1; filePointer--) {
-                // Move pointer to
+                // Move pointer
                 randomAccessFile.seek(filePointer);
                 int readByte = randomAccessFile.readByte();
                 if (0xA == readByte) {


### PR DESCRIPTION
# Description
### Reason why leads to the crash
The testOOM.pdf is in a wrong pdf encoding format as it does not end with '%%EOF' which is the correct ending of any pdf file. As there is no '%%EOF', the program will not stop reading so that the memory will soon be used out, which leads to out of memory.  
### How I solve this problem
To solve this, I added some methods to check whether the file is in pdf format, with header(%PDF-(PDF version)) and end(%%EOF). I read the first 20 bytes to check the header in HEX and read backward from the last line to chech whether it is '%%EOF' in HEX. After doing so, the continuously crash was solved. I can normally open the feature PDF-TO-image without crashing.  
### Still some problems.   
First is that, although the app doesn't crash because of OOM, the code still cannot get rid of the illegal pdf file, which means user can still choose the file. After clicking the transform bottom, the app will crash, but not continously crash.
Second, my code cannot check the format like pdf ending with
```
%%EOF

```
that is a redundant enter.   
### Where I test the app
Using the virtual machine: Pixel 4 API 30 in Android Studio.

Fixes #1061 #1056 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
