### PR TITLE
Fix issue #1063

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,6 +106,8 @@ dependencies {
     implementation 'jp.wasabeef:picasso-transformations:2.2.1'
     implementation 'ja.burhanrashid52:photoeditor:0.2.1'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
+    implementation 'com.github.pqpo:SmartCropper:v2.1.3'
+    //implementation 'vn.tinyhands:photo-cropper:0.0.8'
 
     // Viewpager transformation
     implementation 'com.eftimoff:android-viewpager-transformers:1.0.1@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation 'ja.burhanrashid52:photoeditor:0.2.1'
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
     implementation 'com.github.pqpo:SmartCropper:v2.1.3'
-    //implementation 'vn.tinyhands:photo-cropper:0.0.8'
+
 
     // Viewpager transformation
     implementation 'com.eftimoff:android-viewpager-transformers:1.0.1@aar'

--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -133,6 +133,7 @@ public class CropImageActivity extends AppCompatActivity {
         Bitmap crop = ivCrop.crop();
         mCropImageView.setImageBitmap(crop);
         setContentView(mMainView);
+        cropButtonClicked();
     }
 
     public void cropCancelButtonClicked() {

--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -75,6 +75,10 @@ public class CropImageActivity extends AppCompatActivity {
 
         setImage(0);
 
+        setButtonListener();
+    }
+
+    public void setButtonListener() {
         Button cropImageButton = findViewById(R.id.cropButton);
         cropImageButton.setOnClickListener(view -> cropButtonClicked());
 
@@ -83,8 +87,6 @@ public class CropImageActivity extends AppCompatActivity {
 
         Button modeButton = findViewById(R.id.cropModeButton);
         modeButton.setOnClickListener(view -> cropModeButtonClicked());
-
-
 
         ImageView nextImageButton = findViewById(R.id.nextimageButton);
         nextImageButton.setOnClickListener(view -> nextImageClicked());

--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -6,9 +6,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
-
 import androidx.appcompat.app.AppCompatActivity;
-
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -21,12 +19,10 @@ import android.widget.TextView;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.theartofdev.edmodo.cropper.CropImage;
 import com.theartofdev.edmodo.cropper.CropImageView;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
-
 import butterknife.ButterKnife;
 import swati4star.createpdf.R;
 import swati4star.createpdf.fragment.ImageToPdfFragment;
@@ -149,7 +145,7 @@ public class CropImageActivity extends AppCompatActivity {
     }
 
     public void nextImageClicked() {
-        if (mImages.size() == 0)
+        if ( mImages.size() == 0)
             return;
 
         if (!mCurrentImageEdited) {
@@ -161,7 +157,7 @@ public class CropImageActivity extends AppCompatActivity {
     }
 
     public void prevImgBtnClicked() {
-        if (mImages.size() == 0)
+        if ( mImages.size() == 0)
             return;
 
         if (!mCurrentImageEdited) {
@@ -217,7 +213,6 @@ public class CropImageActivity extends AppCompatActivity {
 
     /**
      * Set image in crop image view & increment counters
-     *
      * @param index - image index
      */
     private void setImage(int index) {

--- a/app/src/main/res/layout/activity_crop_by_quadrilater.xml
+++ b/app/src/main/res/layout/activity_crop_by_quadrilater.xml
@@ -21,14 +21,14 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="cancel" />
+            android:text="@string/cancel" />
 
         <Button
             android:id="@+id/CropOKButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="ok" />
+            android:text="@string/ok" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_crop_by_quadrilater.xml
+++ b/app/src/main/res/layout/activity_crop_by_quadrilater.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <me.pqpo.smartcropperlib.view.CropImageView
+        android:id="@+id/iv_crop"
+        android:layout_width="match_parent"
+        android:layout_height="602dp"
+        android:scaleType="centerInside" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/CropCancelButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="cancel" />
+
+        <Button
+            android:id="@+id/CropOKButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="ok" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_crop_image_activity.xml
+++ b/app/src/main/res/layout/activity_crop_image_activity.xml
@@ -78,7 +78,7 @@
                 android:minWidth="0dp"
                 android:paddingStart="2dp"
                 android:paddingEnd="2dp"
-                android:text="Crop"
+                android:text="@string/crop"
                 android:textAllCaps="false"
                 android:textColor="?attr/bottomSheetTextColor" />
 

--- a/app/src/main/res/layout/activity_crop_image_activity.xml
+++ b/app/src/main/res/layout/activity_crop_image_activity.xml
@@ -44,12 +44,12 @@
 
             <Button
                 android:id="@+id/cropButton"
-                android:layout_width="wrap_content"
-                android:minWidth="40dp"
+                android:layout_width="59dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="2dp"
+                android:layout_marginStart="1dp"
                 android:layout_weight="1"
                 android:background="@drawable/cornered_edges"
+                android:minWidth="40dp"
                 android:text="@string/save_current"
                 android:textAllCaps="false"
                 android:textColor="?attr/bottomSheetTextColor" />
@@ -57,14 +57,28 @@
             <Button
                 android:id="@+id/rotateButton"
                 android:layout_width="wrap_content"
-                android:minWidth="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
+                android:layout_marginStart="1dp"
                 android:layout_weight="1"
                 android:background="@drawable/cornered_edges"
+                android:minWidth="0dp"
                 android:paddingStart="2dp"
                 android:paddingEnd="2dp"
                 android:text="@string/rotate"
+                android:textAllCaps="false"
+                android:textColor="?attr/bottomSheetTextColor" />
+
+            <Button
+                android:id="@+id/cropModeButton"
+                android:layout_width="50dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="1dp"
+                android:layout_weight="1"
+                android:background="@drawable/cornered_edges"
+                android:minWidth="0dp"
+                android:paddingStart="2dp"
+                android:paddingEnd="2dp"
+                android:text="Crop"
                 android:textAllCaps="false"
                 android:textColor="?attr/bottomSheetTextColor" />
 
@@ -72,19 +86,19 @@
                 android:id="@+id/previousImageButton"
                 android:layout_width="0dp"
                 android:layout_height="40dp"
+                android:layout_gravity="center"
                 android:layout_marginStart="5dp"
                 android:layout_weight="3"
                 android:contentDescription="@string/previous_image_content_desc"
                 android:gravity="center"
-                android:layout_gravity="center"
-                app:tint="?attr/bottomSheetColor"
                 app:srcCompat="@drawable/ic_navigate_before_white_24dp"
+                app:tint="?attr/bottomSheetColor"
                 tools:targetApi="lollipop" />
 
             <TextView
                 android:id="@+id/imagecount"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_width="85dp"
+                android:layout_height="49dp"
                 android:layout_weight="8"
                 android:gravity="center"
                 android:text="@string/showing_image" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,6 +580,7 @@
     <string name="storage_manager_permission_rationale">In Android 11, you need to allow a special storage permission</string>
     <string name="close_app_text">Close App</string>
     <string name="allow_text">Allow</string>
+    <string name="string_mode">\@string/mode</string>
     <string-array name="faq_question_answers">
         <item>What image file formats are supported?#####The app supports jpeg, jpg, tiff, gif, psd, bmp, eps, png, etc.</item>
         <item>Can I create a new text file using the app?#####You can only create a new text file by extracting texts from an existing PDFs. To create a text file, \n1) Click the <strong>Extract Text</strong> option on the homepage. \n2) Select the PDF using <strong>SELECT PDF FILE</strong> button. \n3) Then, click <strong>EXTRACT TEXT</strong>. \n4) Once done, a text file with the texts from the PDF file will be created.</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,7 +580,7 @@
     <string name="storage_manager_permission_rationale">In Android 11, you need to allow a special storage permission</string>
     <string name="close_app_text">Close App</string>
     <string name="allow_text">Allow</string>
-    <string name="string_mode">\@string/mode</string>
+    <string name="crop">Crop</string>
     <string-array name="faq_question_answers">
         <item>What image file formats are supported?#####The app supports jpeg, jpg, tiff, gif, psd, bmp, eps, png, etc.</item>
         <item>Can I create a new text file using the app?#####You can only create a new text file by extracting texts from an existing PDFs. To create a text file, \n1) Click the <strong>Extract Text</strong> option on the homepage. \n2) Select the PDF using <strong>SELECT PDF FILE</strong> button. \n3) Then, click <strong>EXTRACT TEXT</strong>. \n4) Once done, a text file with the texts from the PDF file will be created.</item>


### PR DESCRIPTION
	modified:   app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
	new file:   app/src/main/res/layout/activity_crop_by_quadrilater.xml
	modified:   app/src/main/res/layout/activity_crop_image_activity.xml

# Description
Using a lib to fix the issue. Create a new view and need a new dependency.
Dependency:  com.github.pqpo:SmartCropper:v2.1.3
Add a new button point to the new view.
![image](https://user-images.githubusercontent.com/58821193/164951646-1532bf48-6abf-4cbb-8dd7-653b99de8142.png)
By clicking the `Crop` button, the new view is like.
![image](https://user-images.githubusercontent.com/58821193/164951658-3cfd86f6-b587-48c6-885e-1606e02b0163.png)
The pdf is like:
![image](https://user-images.githubusercontent.com/58821193/164951675-102f514a-3063-456a-9ae9-0e1a46190609.png)

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
If there are any UI change, please include the screenshots also.

Fixes #1063 

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on `Pixel 2 API 30` in Android Studio
Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
