### PR TITLE
fix bug 1058

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/PdfToImageFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/PdfToImageFragment.java
@@ -1,15 +1,17 @@
 package swati4star.createpdf.fragment;
 
 
+import static android.app.Activity.RESULT_OK;
+import static swati4star.createpdf.util.Constants.BUNDLE_DATA;
+import static swati4star.createpdf.util.Constants.PDF_TO_IMAGES;
+import static swati4star.createpdf.util.Constants.REQUEST_CODE_FOR_WRITE_PERMISSION;
+import static swati4star.createpdf.util.Constants.WRITE_PERMISSIONS;
+
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import com.google.android.material.bottomsheet.BottomSheetBehavior;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.InputType;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,9 +21,14 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.airbnb.lottie.LottieAnimationView;
 import com.dd.morphingbutton.MorphingButton;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -42,18 +49,13 @@ import swati4star.createpdf.util.CommonCodeUtils;
 import swati4star.createpdf.util.DialogUtils;
 import swati4star.createpdf.util.ExtractImages;
 import swati4star.createpdf.util.FileUtils;
+import swati4star.createpdf.util.ImageUtils;
 import swati4star.createpdf.util.MorphButtonUtility;
 import swati4star.createpdf.util.PDFUtils;
 import swati4star.createpdf.util.PdfToImages;
 import swati4star.createpdf.util.PermissionsUtils;
 import swati4star.createpdf.util.RealPathUtil;
 import swati4star.createpdf.util.StringUtils;
-
-import static android.app.Activity.RESULT_OK;
-import static swati4star.createpdf.util.Constants.BUNDLE_DATA;
-import static swati4star.createpdf.util.Constants.PDF_TO_IMAGES;
-import static swati4star.createpdf.util.Constants.REQUEST_CODE_FOR_WRITE_PERMISSION;
-import static swati4star.createpdf.util.Constants.WRITE_PERMISSIONS;
 
 public class PdfToImageFragment extends Fragment implements BottomSheetPopulate, MergeFilesAdapter.OnClickListener,
         ExtractImagesListener, ExtractImagesAdapter.OnFileItemClickedListener, OnBackPressedInterface {
@@ -64,6 +66,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
     private Uri mUri;
     private MorphButtonUtility mMorphButtonUtility;
     private FileUtils mFileUtils;
+    private ImageUtils mImageUtils;
     private BottomSheetBehavior mSheetBehavior;
     private BottomSheetUtils mBottomSheetUtils;
     private ArrayList<String> mOutputFilePaths;
@@ -117,15 +120,22 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
         return rootView;
     }
 
+
     @OnClick(R.id.viewImagesInGallery)
     void onImagesInGalleryClick() {
         Intent intent = new Intent();
         intent.setAction(Intent.ACTION_VIEW);
-        Uri imagesUri = Uri.parse("content:///storage/emulated/0/PDFfiles/");
-        intent.setDataAndType(imagesUri, "image/*");
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        startActivity(intent);
+        for (int i = 0; i < mOutputFilePaths.size(); i++) {
+            Uri imagesUri = Uri.fromFile(new File(mOutputFilePaths.get(i)));
+            Uri imagesRealUri = mFileUtils.file2Content(imagesUri);
+            mImageUtils.saveImgToGallery(mOutputFilePaths.get(i), mContext);
+            intent.setDataAndType(imagesRealUri, "image/*");
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            startActivity(intent);
+        }
+
     }
+
 
     /**
      * called when user chooses to share generated images
@@ -229,6 +239,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
         mActivity = (Activity) context;
         mMorphButtonUtility = new MorphButtonUtility(mActivity);
         mFileUtils = new FileUtils(mActivity);
+        mImageUtils = ImageUtils.getInstance();
         mBottomSheetUtils = new BottomSheetUtils(mActivity);
         mContext = context;
         mPDFUtils = new PDFUtils(mActivity);
@@ -336,7 +347,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
      ***/
     private void getRuntimePermissions() {
         PermissionsUtils.getInstance().requestRuntimePermissions(this,
-                    WRITE_PERMISSIONS,
-                    REQUEST_CODE_FOR_WRITE_PERMISSION);
+                WRITE_PERMISSIONS,
+                REQUEST_CODE_FOR_WRITE_PERMISSION);
     }
 }

--- a/app/src/main/java/swati4star/createpdf/util/FileUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/FileUtils.java
@@ -2,6 +2,7 @@ package swati4star.createpdf.util;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -386,5 +387,34 @@ public class FileUtils {
                 }
             }
         }).show();
+    }
+
+    public Uri file2Content(Uri uri) {
+        if (uri.getScheme().equals("file")) {
+            String path = uri.getEncodedPath();
+            if (path != null) {
+                path = Uri.decode(path);
+                ContentResolver resolver = this.mContext.getContentResolver();
+                StringBuffer buff = new StringBuffer();
+                buff.append("(")
+                        .append(MediaStore.Images.ImageColumns.DATA)
+                        .append("='" + path + "')");
+                Cursor cur = resolver.query(
+                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                        new String[]{MediaStore.Images.ImageColumns._ID},
+                        buff.toString(), null, null);
+                int index = 0;
+                for (cur.moveToFirst(); !cur.isAfterLast(); cur.moveToNext()) {
+                    index = cur.getInt(cur.getColumnIndex(MediaStore.Images.ImageColumns._ID));
+                }
+                if (index != 0) {
+                    Uri uriTemp = Uri.parse("content://media/external/images/media/" + index);
+                    if (uriTemp != null) {
+                        uri = uriTemp;
+                    }
+                }
+            }
+        }
+        return uri;
     }
 }

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -1,7 +1,10 @@
 package swati4star.createpdf.util;
 
 import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -13,9 +16,12 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
+import android.net.Uri;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.fragment.app.Fragment;
+
+import android.provider.MediaStore;
 import android.util.Log;
 import android.view.View;
 import android.widget.CheckBox;
@@ -276,6 +282,33 @@ public class ImageUtils {
         Canvas canvas = new Canvas(whiteBitmap);
         canvas.drawColor(Color.WHITE);
         return bitmap.sameAs(whiteBitmap);
+    }
+
+    public ContentValues getImageContentValues(File paramFile, long paramLong) {
+        ContentValues localContentValues = new ContentValues();
+        localContentValues.put("title", paramFile.getName());
+        localContentValues.put("_display_name", paramFile.getName());
+        localContentValues.put("mime_type", "image/jpeg");
+        localContentValues.put("datetaken", Long.valueOf(paramLong));
+        localContentValues.put("date_modified", Long.valueOf(paramLong));
+        localContentValues.put("date_added", Long.valueOf(paramLong));
+        localContentValues.put("orientation", Integer.valueOf(0));
+        localContentValues.put("_data", paramFile.getAbsolutePath());
+        localContentValues.put("_size", Long.valueOf(paramFile.length()));
+        return localContentValues;
+    }
+
+    public void saveImgToGallery(String imageFile, Context context) {
+        try {
+            ContentResolver resolver = context.getContentResolver();
+            ContentValues contentValues = getImageContentValues(new File(imageFile), System.currentTimeMillis());
+            resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
+            Intent intent = new Intent("android.intent.action.MEDIA_SCANNER_SCAN_FILE");
+            intent.setData(Uri.fromFile(new File(imageFile)));
+            context.sendBroadcast(intent);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
 


### PR DESCRIPTION
# Description

Modify PdfToImageFragment.java: In method onImagesInGalleryClick(), the original image URI is an invalid and fixed URI "content:///storage/emulated/0/PDFfiles/". I replace this URI with the URI of the generated image, and create an util method file2Content in FileUtils.java to convert URI starts with"file://" to URI starts with "content://", and then save the images to the gallery.
Now "view images in gallery" button can show generated images in gallery.

![{MG7V}IF)XNOW%%BO)R_SB9](https://user-images.githubusercontent.com/75576791/164967123-01a80a6c-7dfe-4194-aee2-c819565e323d.png)


Fixes #1058

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on Pixel 2 API 30 in Android Studio
Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
