### PR TITLE
Fix 1053: Storage location not created and setting not honored

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -41,6 +41,7 @@ import swati4star.createpdf.util.DirectoryUtils;
 import swati4star.createpdf.util.PermissionsUtils;
 import swati4star.createpdf.util.ThemeUtils;
 import swati4star.createpdf.util.WhatsNewUtils;
+import swati4star.createpdf.util.StringUtils;
 
 import static swati4star.createpdf.util.Constants.IS_WELCOME_ACTIVITY_SHOWN;
 import static swati4star.createpdf.util.Constants.LAUNCH_COUNT;
@@ -67,6 +68,8 @@ public class MainActivity extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         ThemeUtils.getInstance().setThemeApp(this);
+        StringUtils.getInstance().setContext(this);
+        StringUtils.getInstance().getStorageLocation();
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);

--- a/app/src/main/java/swati4star/createpdf/fragment/SettingsFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/SettingsFragment.java
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-//import butterknife.OnClick;
-//import lib.folderpicker.FolderPicker;
+import butterknife.OnClick;
+import lib.folderpicker.FolderPicker;
 import swati4star.createpdf.R;
 import swati4star.createpdf.adapter.EnhancementOptionsAdapter;
 import swati4star.createpdf.interfaces.OnItemClickListener;
@@ -74,17 +74,16 @@ public class SettingsFragment extends Fragment implements OnItemClickListener {
         View root = inflater.inflate(R.layout.fragment_settings, container, false);
         ButterKnife.bind(this, root);
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(mActivity);
-        storageLocation.setText(mSharedPreferences.getString(STORAGE_LOCATION,
-                StringUtils.getInstance().getDefaultStorageLocation()));
+        storageLocation.setText(StringUtils.getInstance().getStorageLocation());
         showSettingsOptions();
         return root;
     }
 
-//    @OnClick(R.id.storagelocation)
-//    void modifyStorageLocation() {
-////        Intent intent = new Intent(mActivity, FolderPicker.class);
-////        startActivityForResult(intent, MODIFY_STORAGE_LOCATION_CODE);
-//    }
+    @OnClick(R.id.storagelocation)
+    void modifyStorageLocation() {
+        Intent intent = new Intent(mActivity, FolderPicker.class);
+        startActivityForResult(intent, MODIFY_STORAGE_LOCATION_CODE);
+    }
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -13,7 +13,6 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
-import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.fragment.app.Fragment;
 import android.util.Log;
@@ -36,7 +35,6 @@ import swati4star.createpdf.R;
 import static swati4star.createpdf.util.Constants.AUTHORITY_APP;
 import static swati4star.createpdf.util.Constants.IMAGE_SCALE_TYPE_ASPECT_RATIO;
 import static swati4star.createpdf.util.Constants.IMAGE_SCALE_TYPE_STRETCH;
-import static swati4star.createpdf.util.Constants.pdfDirectory;
 
 public class ImageUtils {
 
@@ -226,8 +224,8 @@ public class ImageUtils {
         if (finalBitmap == null || checkIfBitmapIsWhite(finalBitmap))
             return null;
 
-        String root = Environment.getExternalStorageDirectory().toString();
-        File myDir = new File(root + pdfDirectory);
+        String root = StringUtils.getInstance().getStorageLocation();
+        File myDir = new File(root);
         String fileName = filename + ".png";
 
         File file = new File(myDir, fileName);

--- a/app/src/main/java/swati4star/createpdf/util/StringUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/StringUtils.java
@@ -7,6 +7,9 @@ import com.google.android.material.snackbar.Snackbar;
 import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.content.SharedPreferences;
+import android.content.Context;
+import android.preference.PreferenceManager;
 
 import java.io.File;
 import java.util.Objects;
@@ -14,6 +17,7 @@ import java.util.Objects;
 //import static swati4star.createpdf.util.Constants.PATH_SEPERATOR;
 import static swati4star.createpdf.util.Constants.PATH_SEPERATOR;
 import static swati4star.createpdf.util.Constants.pdfDirectory;
+import static swati4star.createpdf.util.Constants.STORAGE_LOCATION;
 //import static swati4star.createpdf.util.Constants.pdfDirectory;
 
 /**
@@ -22,15 +26,18 @@ import static swati4star.createpdf.util.Constants.pdfDirectory;
 
 public class StringUtils {
 
+    Context mContext;
     private StringUtils() {
     }
 
-    private static class SingletonHolder {
-        static final StringUtils INSTANCE = new StringUtils();
-    }
+    private static StringUtils stringUtils  = new StringUtils();
 
     public static StringUtils getInstance() {
-        return StringUtils.SingletonHolder.INSTANCE;
+        return stringUtils;
+    }
+
+    public void setContext(Context context) {
+        this.mContext = context;
     }
 
     public boolean isEmpty(CharSequence s) {
@@ -98,5 +105,17 @@ public class StringUtils {
             return def;
         else
             return Integer.parseInt(text.toString());
+    }
+
+    public String getStorageLocation() {
+        SharedPreferences mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(this.mContext);
+        String storageLocation = mSharedPreferences.getString(STORAGE_LOCATION,
+                StringUtils.getInstance().getDefaultStorageLocation());
+        System.out.println(storageLocation);
+        File file = new File(storageLocation);
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+        return storageLocation;
     }
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.
If there are any UI change, please include the screenshots also.
+ let defaultstorage path will be created with the mainActivity start
+ create a unified entrance to get the default path
+ let user can modify the storage path (use the original code,I why don't why it is commented out). I test it on api 26 and api 30 ,it works well.

Fixes #1053 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
