### PR TITLE
Fix bug #1078

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
@@ -97,7 +97,7 @@ public class CreatePdf extends AsyncTask<String, String, String> {
      * @param imageUris   - Uris of images that will be converted to PDF
      *
      */
-    private void deleteTempImages(ArrayList<String> imageUris) {
+    public void deleteTempImages(ArrayList<String> imageUris) {
         for (int i = 0; i < imageUris.size(); i++) {
             String imagePath = imageUris.get(i);
             if (!imagePath.contains("temp")) {

--- a/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
@@ -4,7 +4,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.AsyncTask;
+
 import androidx.annotation.NonNull;
+
 import android.util.Log;
 
 import com.itextpdf.text.BaseColor;
@@ -89,6 +91,25 @@ public class CreatePdf extends AsyncTask<String, String, String> {
         if (!folder.exists())
             folder.mkdir();
         mPath = mPath + mFileName + pdfExtension;
+    }
+
+    /***
+     * This method is used to delete temporary image files generated during 'Zip to PDF'
+     *
+     * @param imageUris   - Uris of images that will be converted to PDF
+     *
+     */
+    private void deleteTempImages(ArrayList<String> imageUris) {
+        for (int i = 0; i < imageUris.size(); i++) {
+            String imagePath = imageUris.get(i);
+            if (!imagePath.contains("temp")) {
+                continue;
+            }
+            File f = new File(imagePath);
+            if (f.exists()) {
+                f.delete();
+            }
+        }
     }
 
     @Override
@@ -178,6 +199,8 @@ public class CreatePdf extends AsyncTask<String, String, String> {
         } catch (Exception e) {
             e.printStackTrace();
             mSuccess = false;
+        } finally {
+            deleteTempImages(mImagesUri);
         }
 
         return null;

--- a/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
@@ -4,9 +4,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.AsyncTask;
-
 import androidx.annotation.NonNull;
-
 import android.util.Log;
 
 import com.itextpdf.text.BaseColor;

--- a/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/CreatePdf.java
@@ -98,12 +98,11 @@ public class CreatePdf extends AsyncTask<String, String, String> {
      *
      */
     public void deleteTempImages(ArrayList<String> imageUris) {
-        for (int i = 0; i < imageUris.size(); i++) {
-            String imagePath = imageUris.get(i);
-            if (!imagePath.contains("temp")) {
+        for (String imageUri : imageUris) {
+            if (!imageUri.contains("temp")) {
                 continue;
             }
-            File f = new File(imagePath);
+            File f = new File(imageUri);
             if (f.exists()) {
                 f.delete();
             }

--- a/app/src/main/java/swati4star/createpdf/util/ZipToPdf.java
+++ b/app/src/main/java/swati4star/createpdf/util/ZipToPdf.java
@@ -42,7 +42,7 @@ public class ZipToPdf {
         BufferedOutputStream bufferedOutputStream;
         ArrayList<Uri> imageUris = new ArrayList<>();
         DirectoryUtils.makeAndClearTemp();
-        String dest = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS).toString() +
+        String dest = Environment.getExternalStorageDirectory().toString() +
                 pdfDirectory + tempDirectory;
 
         try {


### PR DESCRIPTION
# Description

To fix this bug, I first modify the path "dest" in ZipToPdf.java in method convertZipToPDF. Secondly, I add a method deleteTempImages to delete temporary images generated during conversion, and this will be invoked after converting images to PDF files

Fixes #1078

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
