### PR TITLE
fix bugs induced by android:drawableTint

### DIFF
--- a/app/src/main/res/layout/fragment_about_us.xml
+++ b/app/src/main/res/layout/fragment_about_us.xml
@@ -3,7 +3,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -56,7 +57,7 @@
                     android:layout_gravity="center_vertical"
                     android:drawableStart="@drawable/ic_version_white_24dp"
                     android:drawablePadding="15dp"
-                    android:drawableTint="?attr/historyIconColor"
+                    app:drawableTint="?attr/historyIconColor"
                     android:padding="8dp"
                     android:text="@string/version"
                     tools:targetApi="m" />
@@ -76,7 +77,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_person_white_24dp"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/developer"
                 tools:targetApi="m" />
@@ -95,7 +96,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_email_24dp"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/mail"
                 tools:targetApi="m" />
@@ -114,7 +115,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_github"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/github_repo"
                 tools:targetApi="m" />
@@ -133,7 +134,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_people_black_24dp"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/view_contributors"
                 tools:targetApi="m" />
@@ -152,7 +153,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_playstore"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/playstore"
                 tools:targetApi="m" />
@@ -171,7 +172,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_web"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/website"
                 tools:targetApi="m" />
@@ -190,7 +191,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_slack"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/join_slack"
                 tools:targetApi="m" />
@@ -209,7 +210,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_lock_black_24dp"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/privacy_policy"
                 tools:targetApi="m" />
@@ -228,7 +229,7 @@
                 android:layout_gravity="center_vertical"
                 android:drawableStart="@drawable/ic_license"
                 android:drawablePadding="15dp"
-                android:drawableTint="?attr/historyIconColor"
+                app:drawableTint="?attr/historyIconColor"
                 android:padding="8dp"
                 android:text="@string/license"
                 tools:targetApi="m" />


### PR DESCRIPTION
# Description

I found that you use the attribute android:drawableTint in the file fragment_about_us.xml. Such an attribute can induce incompatibilities at API level below 23.

API level 32
![2b19381ed0cb5ca6f2e0b269a5e7eae](https://user-images.githubusercontent.com/109571086/179684181-10904642-b0b8-4cf9-baaa-b0e379054157.png)

API level 22 and 23
![5dc781cf9e3e161d355a692088132b1](https://user-images.githubusercontent.com/109571086/179684731-ce387ff7-b541-4002-9588-c55be5296147.png)


This pull request changes android:drawableTint to app:drawableTint so that the icons look the same among API levels.

## Type of change
Just put an x in the [] which are valid.
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Open the app
2. Click "Option" button
3. Choose "About Us"
4. Notice the orange icon colors at API level 22 and 23 

# Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
