### PR TITLE
Implement Proper "View Images in Gallery" Button Functionality

### DIFF
--- a/app/src/main/java/swati4star/createpdf/fragment/PdfToImageFragment.java
+++ b/app/src/main/java/swati4star/createpdf/fragment/PdfToImageFragment.java
@@ -48,6 +48,7 @@ import swati4star.createpdf.util.PdfToImages;
 import swati4star.createpdf.util.PermissionsUtils;
 import swati4star.createpdf.util.RealPathUtil;
 import swati4star.createpdf.util.StringUtils;
+import swati4star.createpdf.util.ImageUtils;
 
 import static android.app.Activity.RESULT_OK;
 import static swati4star.createpdf.util.Constants.BUNDLE_DATA;
@@ -72,6 +73,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
     private Context mContext;
     private PDFUtils mPDFUtils;
     private String[] mInputPassword;
+    private ImageUtils mImageUtils;
 
     @BindView(R.id.lottie_progress)
     LottieAnimationView mLottieProgress;
@@ -109,7 +111,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
         ButterKnife.bind(this, rootView);
         mOperation = getArguments().getString(BUNDLE_DATA);
         mSheetBehavior = BottomSheetBehavior.from(mLayoutBottomSheet);
-        mSheetBehavior.setBottomSheetCallback(new BottomSheetCallback(mUpArrow, isAdded()));
+        mSheetBehavior.addBottomSheetCallback(new BottomSheetCallback(mUpArrow, isAdded()));
         mLottieProgress.setVisibility(View.VISIBLE);
         mBottomSheetUtils.populateBottomSheetWithPDFs(this);
         resetView();
@@ -117,15 +119,21 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
         return rootView;
     }
 
+
     @OnClick(R.id.viewImagesInGallery)
     void onImagesInGalleryClick() {
         Intent intent = new Intent();
         intent.setAction(Intent.ACTION_VIEW);
-        Uri imagesUri = Uri.parse("content:///storage/emulated/0/PDFfiles/");
-        intent.setDataAndType(imagesUri, "image/*");
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        startActivity(intent);
+        for (int i = 0; i < mOutputFilePaths.size(); i++) {
+            Uri imagesUri = Uri.fromFile(new File(mOutputFilePaths.get(i)));
+            Uri imagesRealUri = mFileUtils.getContent(imagesUri);
+            mImageUtils.saveImgToGallery(mOutputFilePaths.get(i), mContext);
+            intent.setDataAndType(imagesRealUri, "image/*");
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            startActivity(intent);
+        }
     }
+
 
     /**
      * called when user chooses to share generated images
@@ -229,6 +237,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
         mActivity = (Activity) context;
         mMorphButtonUtility = new MorphButtonUtility(mActivity);
         mFileUtils = new FileUtils(mActivity);
+        mImageUtils = ImageUtils.getInstance();
         mBottomSheetUtils = new BottomSheetUtils(mActivity);
         mContext = context;
         mPDFUtils = new PDFUtils(mActivity);
@@ -336,7 +345,7 @@ public class PdfToImageFragment extends Fragment implements BottomSheetPopulate,
      ***/
     private void getRuntimePermissions() {
         PermissionsUtils.getInstance().requestRuntimePermissions(this,
-                    WRITE_PERMISSIONS,
-                    REQUEST_CODE_FOR_WRITE_PERMISSION);
+                WRITE_PERMISSIONS,
+                REQUEST_CODE_FOR_WRITE_PERMISSION);
     }
 }

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -1,7 +1,10 @@
 package swati4star.createpdf.util;
 
 import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -13,9 +16,12 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
+import android.net.Uri;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.fragment.app.Fragment;
+
+import android.provider.MediaStore;
 import android.util.Log;
 import android.view.View;
 import android.widget.CheckBox;
@@ -276,6 +282,33 @@ public class ImageUtils {
         Canvas canvas = new Canvas(whiteBitmap);
         canvas.drawColor(Color.WHITE);
         return bitmap.sameAs(whiteBitmap);
+    }
+
+    public ContentValues getImageContentValues(File paramFile, long paramLong) {
+        ContentValues localContentValues = new ContentValues();
+        localContentValues.put("title", paramFile.getName());
+        localContentValues.put("_display_name", paramFile.getName());
+        localContentValues.put("mime_type", "image/jpeg");
+        localContentValues.put("datetaken", paramLong);
+        localContentValues.put("date_modified", paramLong);
+        localContentValues.put("date_added", paramLong);
+        localContentValues.put("orientation", 0);
+        localContentValues.put("_data", paramFile.getAbsolutePath());
+        localContentValues.put("_size", paramFile.length());
+        return localContentValues;
+    }
+
+    public void saveImgToGallery(String imageFile, Context context) {
+        try {
+            ContentResolver resolver = context.getContentResolver();
+            ContentValues contentValues = getImageContentValues(new File(imageFile), System.currentTimeMillis());
+            resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues);
+            Intent intent = new Intent("android.intent.action.MEDIA_SCANNER_SCAN_FILE");
+            intent.setData(Uri.fromFile(new File(imageFile)));
+            context.sendBroadcast(intent);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
 


### PR DESCRIPTION
# Description

After extracting image(s) from a PDF, the "View Images in Gallery" button would fail to actually show the extracted images in the Gallery. This change makes this button functional by putting the correct image content in the URI, which was done by building on a previous pull request that made acceptable changes to the ImageUtils.java file, but this change also adds changes to the FileUtils.java file, as well as the PdfToImageFragment.java file.

Fixes #1058

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
