### PR TITLE
fix-vulnerabilities-itext

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation group: 'org.apache.poi', name: 'poi-scratchpad', version: '3.9'
 
     // Itext pdf library
-    implementation 'com.itextpdf:itextg:5.5.10'
+    implementation group: 'com.itextpdf', name: 'itextpdf', version: '5.5.13.3'
     implementation 'com.madgag.spongycastle:core:1.58.0.0'
 
     // Picasso, image editor, image cropper


### PR DESCRIPTION
# Description

This pull-request contains a quick fix on the itext library, in fact, the master branch was using the version 5.5.10 of the itext library containing  lot of vulnerabilities. I changed the 5.5.10 old version to 5.5.13.3 version in the .gradle file.

Fixes #(issue)
itext vulnerabilities issues fix.

## Type of change
Just put an x in the [] which are valid.
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
