### PR TITLE
Match with latest AGP(Android Gradle Plugin) version and conventions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,20 +33,19 @@ android {
         javaMaxHeapSize "4g"
     }
     packagingOptions {
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/LICENSE.txt'
-    }
-    lintOptions {
-        checkReleaseBuilds false
+        resources {
+            excludes += ['META-INF/DEPENDENCIES', 'META-INF/NOTICE', 'META-INF/LICENSE', 'META-INF/NOTICE.txt', 'META-INF/LICENSE.txt']
+        }
     }
     testOptions {
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
         }
+    }
+    namespace 'swati4star.createpdf'
+    lint {
+        checkReleaseBuilds false
     }
 }
 configurations {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,9 +29,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
     packagingOptions {
         resources {
             excludes += ['META-INF/DEPENDENCIES', 'META-INF/NOTICE', 'META-INF/LICENSE', 'META-INF/NOTICE.txt', 'META-INF/LICENSE.txt']

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="swati4star.createpdf">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
 
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.google.gms:google-services:4.3.15'

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,7 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryErr
 android.enableD8=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8.fullMode=false
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryErr
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.enableD8=true
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8.fullMode=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip


### PR DESCRIPTION
### Description
- Updated Android Gradle Plugin from 7.0.4 -> 8.0.1
- Moved package name from AndroidManifest.xml to module level build.gradle as per new conventions
- Removed `android.enableD8` property from gradle.properties file as it is `true` by default since AGP v7.0
- Removed `dexOptions{}` block from build.gradle (module level) as it is obsolete since AGP v8.0 and now dex properties are automatically managed

#### Tested on -
- [Physical Device] (API 33)
