### PR TITLE
add button to grant access certain folders 

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -284,6 +284,22 @@ public class MainActivity extends AppCompatActivity
                         .setData(Uri.fromParts("package", MainActivity.this.getPackageName(), null))
         );
     }
+    private static final int REQUEST_CODE_OPEN_DIRECTORY = 42;
+
+    private void openDirectoryForPermission() {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        startActivityForResult(intent, REQUEST_CODE_OPEN_DIRECTORY);
+    }
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == REQUEST_CODE_OPEN_DIRECTORY && resultCode == RESULT_OK) {
+            Uri uri = data.getData();
+            grantUriPermission(getPackageName(), uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        }
+    }
 
     private void requestStoragePermission_API30AndAbove(boolean giveExplanation) {
         DialogUtils.showChoiceDialog(
@@ -300,6 +316,9 @@ public class MainActivity extends AppCompatActivity
                 giveExplanation ?
                         R.string.manage_storage_permission_denied_alert_dialog_negative_button_label :
                         R.string.manage_storage_permission_alert_dialog_negative_button_label,
+                giveExplanation ?
+                        R.string.manage_storage_permission_alert_dialog_neutral_button_label :
+                        DialogUtils.EMPTY_STRING,
                 false,
                 new DialogCallbacks() {
                     @RequiresApi(api = Build.VERSION_CODES.R)
@@ -321,6 +340,7 @@ public class MainActivity extends AppCompatActivity
 
                     @Override
                     public void onNeutralButtonClick() {
+                        openDirectoryForPermission();
                     }
                 });
     }

--- a/app/src/main/java/swati4star/createpdf/util/DialogUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/DialogUtils.java
@@ -170,7 +170,34 @@ public class DialogUtils {
                 }))
                 .show();
     }
-
+    public static void showChoiceDialog(
+            Context context,
+            int title,
+            int message,
+            int positiveButtonLabel,
+            int negativeButtonLabel,
+            int neutralButtonLabel,
+            boolean cancelable,
+            final DialogCallbacks callbacks
+    ) {
+        new AlertDialog.Builder(context)
+                .setTitle(title == EMPTY_STRING ? "" : context.getString(title))
+                .setMessage(message == EMPTY_STRING ? "" : context.getString(message))
+                .setCancelable(cancelable)
+                .setPositiveButton(positiveButtonLabel, (dialog, which) -> {
+                    callbacks.onPositiveButtonClick();
+                    dialog.dismiss();
+                })
+                .setNegativeButton(negativeButtonLabel, ((dialog, which) -> {
+                    callbacks.onNegativeButtonClick();
+                    dialog.dismiss();
+                }))
+                .setNeutralButton(neutralButtonLabel, ((dialog, which) -> {
+                    callbacks.onNeutralButtonClick();
+                    dialog.dismiss();
+                }))
+                .show();
+    }
     private static class SingletonHolder {
         static final DialogUtils INSTANCE = new DialogUtils();
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,7 +572,8 @@
     <!--  FAQs  -->
     <string name="faqSearch">Search FAQ</string>
     <string name="manage_storage_permission_alert_dialog_title" translatable="false">Allow app to access files on your device</string>
-    <string name="manage_storage_permission_alert_dialog_positive_button_label" translatable="false">Allow</string>
+    <string name="manage_storage_permission_alert_dialog_positive_button_label" translatable="false">Allow All</string>
+    <string name="manage_storage_permission_alert_dialog_neutral_button_label" translatable="false">Allow Selected</string>
     <string name="manage_storage_permission_alert_dialog_negative_button_label" translatable="false">Deny</string>
     <string name="manage_storage_permission_denied_alert_dialog_title" translatable="false">Permission denied</string>
     <string name="manage_storage_permission_denied_alert_dialog_message" translatable="false">Without storage permission the app is unable to read files from your device. Are you sure you want to deny this permission?</string>


### PR DESCRIPTION
# Description

When asking for permission to access the whole file system, add a choice to let the user choose a specific folder

fixes#1129 

PS: Android OS 14 released this week introduces Selected Photos Access, which allows users to grant apps access to specific images and videos in their library, rather than granting access to all media of a given type. This new change is related to data security requirement in #1129. Might take a look.

## Type of change

Just put an x in the [] which are valid.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
