### PR TITLE
[#1103] Added the jpg output format as apart of the PNG, improve for compatibility

### DIFF
--- a/app/src/main/java/swati4star/createpdf/util/ExtractImages.java
+++ b/app/src/main/java/swati4star/createpdf/util/ExtractImages.java
@@ -51,11 +51,9 @@ public class ExtractImages extends AsyncTask<Void, Void, Void> {
                     if (type != null && type.toString().equals(PdfName.IMAGE.toString())) {
                         PdfImageObject pio = new PdfImageObject(stream);
                         byte[] image = pio.getImageAsBytes();
-                        Bitmap bmp = BitmapFactory.decodeByteArray(image, 0,
-                                image.length);
-                        String filename = getFileNameWithoutExtension(mPath) +
-                                "_" + (mImagesCount + 1);
-                        String path = saveImage(filename, bmp);
+                        Bitmap bmp = BitmapFactory.decodeByteArray(image, 0, image.length);
+                        String filename = getFileNameWithoutExtension(mPath) + "_" + (mImagesCount + 1);
+                        String path = saveImage(filename, bmp, ImageUtils.ImageFormat.JPEG);  // Specify JPEG format here
                         if (path != null) {
                             mOutputFilePaths.add(path);
                             mImagesCount++;
@@ -66,7 +64,6 @@ public class ExtractImages extends AsyncTask<Void, Void, Void> {
         } catch (IOException e) {
             e.printStackTrace();
         }
-
         return null;
     }
 

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -81,6 +81,9 @@ public class ImageUtils {
         BitmapFactory.decodeFile(imageFile.getAbsolutePath(), options);
         return new Rectangle(options.outWidth, options.outHeight);
     }
+    public enum ImageFormat {
+        PNG, JPEG
+    }
 
     /**
      * Saves bitmap to external storage
@@ -88,14 +91,14 @@ public class ImageUtils {
      * @param filename    - name of the file
      * @param finalBitmap - bitmap to save
      */
-    public static String saveImage(String filename, Bitmap finalBitmap) {
-
+    public static String saveImage(String filename, Bitmap finalBitmap, ImageFormat format) {
         if (finalBitmap == null || checkIfBitmapIsWhite(finalBitmap))
             return null;
 
         String root = Environment.getExternalStorageDirectory().toString();
         File myDir = new File(root + pdfDirectory);
-        String fileName = filename + ".png";
+        String fileExtension = format == ImageFormat.PNG ? ".png" : ".jpg";
+        String fileName = filename + fileExtension;
 
         File file = new File(myDir, fileName);
         if (file.exists())
@@ -103,12 +106,15 @@ public class ImageUtils {
 
         try {
             FileOutputStream out = new FileOutputStream(file);
-            finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, out);
+            Bitmap.CompressFormat compressFormat = format == ImageFormat.PNG ?
+                    Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG;
+            finalBitmap.compress(compressFormat, 100, out);
             Log.v("saving", fileName);
             out.flush();
             out.close();
         } catch (Exception e) {
             e.printStackTrace();
+            return null;
         }
 
         return myDir + "/" + fileName;

--- a/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
+++ b/app/src/main/java/swati4star/createpdf/util/ImageUtils.java
@@ -86,38 +86,81 @@ public class ImageUtils {
     }
 
     /**
-     * Saves bitmap to external storage
+     * Saves the given bitmap image to external storage in the specified format.
      *
-     * @param filename    - name of the file
-     * @param finalBitmap - bitmap to save
+     * @param filename   The name of the file to be saved.
+     * @param finalBitmap The bitmap image to be saved.
+     * @param format      The desired image format (e.g., PNG, JPEG).
+     * @return The full path to the saved file, or null if the image could not be saved.
      */
     public static String saveImage(String filename, Bitmap finalBitmap, ImageFormat format) {
-        if (finalBitmap == null || checkIfBitmapIsWhite(finalBitmap))
-            return null;
+        if (isInvalidBitmap(finalBitmap)) return null;
 
+        String fullPath = prepareFilePath(filename, format);
+        if (fullPath == null) return null;
+
+        if (!writeImageToFile(finalBitmap, fullPath, format)) {
+            return null;
+        }
+
+        return fullPath;
+    }
+
+    /**
+     * Checks if the provided bitmap is either null or white.
+     *
+     * @param bitmap The bitmap image to check.
+     * @return True if the bitmap is invalid, false otherwise.
+     */
+    private static boolean isInvalidBitmap(Bitmap bitmap) {
+        return bitmap == null || checkIfBitmapIsWhite(bitmap);
+    }
+
+    /**
+     * Prepares the file path for the image to be saved based on the filename and desired format.
+     *
+     * @param filename The name of the file to be saved.
+     * @param format   The desired image format (e.g., PNG, JPEG).
+     * @return The prepared file path string, or null if the path couldn't be prepared.
+     */
+    private static String prepareFilePath(String filename, ImageFormat format) {
         String root = Environment.getExternalStorageDirectory().toString();
         File myDir = new File(root + pdfDirectory);
+
         String fileExtension = format == ImageFormat.PNG ? ".png" : ".jpg";
         String fileName = filename + fileExtension;
 
         File file = new File(myDir, fileName);
-        if (file.exists())
+        if (file.exists()) {
             file.delete();
-
-        try {
-            FileOutputStream out = new FileOutputStream(file);
-            Bitmap.CompressFormat compressFormat = format == ImageFormat.PNG ?
-                    Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG;
-            finalBitmap.compress(compressFormat, 100, out);
-            Log.v("saving", fileName);
-            out.flush();
-            out.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
         }
 
         return myDir + "/" + fileName;
+    }
+
+    /**
+     * Writes the given bitmap image to the specified file path in the desired format.
+     *
+     * @param bitmap   The bitmap image to write.
+     * @param fullPath The full path where the image should be written.
+     * @param format   The desired image format (e.g., PNG, JPEG).
+     * @return True if the image was successfully written, false otherwise.
+     */
+    private static boolean writeImageToFile(Bitmap bitmap, String fullPath, ImageFormat format) {
+        try {
+            FileOutputStream out = new FileOutputStream(new File(fullPath));
+            Bitmap.CompressFormat compressFormat = format == ImageFormat.PNG ?
+                    Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG;
+
+            bitmap.compress(compressFormat, 100, out);
+            Log.v("saving", fullPath);
+            out.flush();
+            out.close();
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
     /**

--- a/app/src/main/java/swati4star/createpdf/util/PdfToImages.java
+++ b/app/src/main/java/swati4star/createpdf/util/PdfToImages.java
@@ -91,9 +91,13 @@ public class PdfToImages extends AsyncTask<Void, Void, Void> {
                     // generate numbered image file names
                     String filename = getFileNameWithoutExtension(mPath) +
                             "_" + (i + 1);
-                    String path = saveImage(filename, bitmap);
+                    //generate png and jpg
+                    String path = saveImage(filename, bitmap, ImageUtils.ImageFormat.JPEG);
+                    String path2 = saveImage(filename, bitmap, ImageUtils.ImageFormat.PNG);
+
                     if (path != null) {
                         mOutputFilePaths.add(path);
+                        mOutputFilePaths.add(path2);
                         mImagesCount++;
                     }
                 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. List any dependencies that are
required for this change.
Add a new JPG output format which suits for devices that do not support PNG
Users can self-select their preferred format
Here's a demo video
https://github.com/Swati4star/Images-to-PDF/assets/97233980/953a7d3d-7365-4338-8540-2a01b1211cfe

![video demo](https://github.com/Swati4star/Images-to-PDF/assets/97233980/3d6969c5-bf2d-4d47-b409-ef29dd096d52)


Fixes #(issue)
Fixes #1103 

## Type of change

Just put an x in the [] which are valid.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
The demo video shows that when PDF is converted to image, it will generate both PNG and JPG files.
<img width="1148" alt="Screenshot 2023-10-28 at 1 47 37 pm" src="https://github.com/Swati4star/Images-to-PDF/assets/97233980/8c3ecefc-16b0-4e01-aba7-97ab3503aae4">
<img width="1085" alt="Screenshot 2023-10-28 at 1 47 31 pm" src="https://github.com/Swati4star/Images-to-PDF/assets/97233980/387518e4-0932-4913-a614-e07aef8122c8">


- [x] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
