### PR TITLE
Change Reset Button layout_width to 75dp and Imagecount layout_width …

### DIFF
--- a/app/src/main/res/layout/activity_photo_editor.xml
+++ b/app/src/main/res/layout/activity_photo_editor.xml
@@ -17,7 +17,7 @@
 
         <Button
             android:id="@+id/resetCurrent"
-            android:layout_width="50dp"
+            android:layout_width="75dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="5dp"
             android:background="@drawable/cornered_edges"
@@ -51,7 +51,7 @@
 
         <TextView
             android:id="@+id/imagecount"
-            android:layout_width="150dp"
+            android:layout_width="125dp"
             android:layout_height="match_parent"
             android:gravity="center"
             android:text="@string/showing_image" />


### PR DESCRIPTION
…to 125dp

# Description

The Reset button was not wide enough for the text, and the text was wrapping.

Fixes #(issue)

Adjusted the width of the Reset button to 75dp.
Also adjusted the width of Imagecount to 125dp because the next Image arrow was getting cut off on smaller devices after increasing the width of the Reset Button.

## Screenshots from two different virtual Devices
### Pixel Fold Open
![Pixel Fold Open](https://github.com/user-attachments/assets/907c2b21-99dd-4c4f-a0d9-fb75e65cd7d6)

### Pixel Fold Closed
![Pixel Fold Closed](https://github.com/user-attachments/assets/a1926415-1e87-4b56-9bcd-701aedf071e8)

### Small Android Phone
![Small Phone](https://github.com/user-attachments/assets/52685217-031e-4d33-8575-d36a5101652f)



## Type of change

Just put an x in the [] which are valid.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x ] `./gradlew assembleDebug assembleRelease`
- [ x] `./gradlew checkstyle`

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
