### PR TITLE
Feature nav

### DIFF
--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -82,6 +82,20 @@ public class CropImageActivity extends AppCompatActivity {
         settingsMenuItem.setBackgroundColor(defaultColor);
         // 添加其他菜单项
     }
+    @Override
+    public void onNavigationItemSelected(int position) {
+        switch (position) {
+            case 0: // 首页
+                currentPage = "home";
+                startActivity(new Intent(this, HomeActivity.class));
+                break;
+            case 1: // 设置
+                currentPage = "settings";
+                startActivity(new Intent(this, SettingsActivity.class));
+                break;
+            // 添加其他页面的情况
+        }
+    }
     public void cropButtonClicked() {
         mCurrentImageEdited = false;
         String root = Environment.getExternalStorageDirectory().toString();

--- a/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/CropImageActivity.java
@@ -76,6 +76,12 @@ public class CropImageActivity extends AppCompatActivity {
         previousImageButton.setOnClickListener(view -> prevImgBtnClicked());
     }
 
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     public void cropButtonClicked() {
         mCurrentImageEdited = false;
         String root = Environment.getExternalStorageDirectory().toString();

--- a/app/src/main/java/swati4star/createpdf/activity/FavouritesActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/FavouritesActivity.java
@@ -131,6 +131,21 @@ public class FavouritesActivity extends AppCompatActivity {
         // 添加其他菜单项
     }
 
+    @Override
+    public void onNavigationItemSelected(int position) {
+        switch (position) {
+            case 0: // 首页
+                currentPage = "home";
+                startActivity(new Intent(this, HomeActivity.class));
+                break;
+            case 1: // 设置
+                currentPage = "settings";
+                startActivity(new Intent(this, SettingsActivity.class));
+                break;
+            // 添加其他页面的情况
+        }
+    }
+
     /**
      * Restore the initial state if user
      * press the back button

--- a/app/src/main/java/swati4star/createpdf/activity/FavouritesActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/FavouritesActivity.java
@@ -64,6 +64,19 @@ public class FavouritesActivity extends AppCompatActivity {
         return true;
     }
 
+  //创建一个方法来根据 currentPage 更新导航菜单的高亮状态
+    private void updateNavigationHighlight() {
+        // 清除所有菜单项的高亮
+        clearHighlights();
+
+        // 根据当前页面高亮对应菜单项
+        if ("home".equals(currentPage)) {
+            // 设置首页菜单项高亮
+        } else if ("settings".equals(currentPage)) {
+            // 设置设置菜单项高亮
+        }
+        // 根据需要添加其他页面的处理
+    }
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {

--- a/app/src/main/java/swati4star/createpdf/activity/FavouritesActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/FavouritesActivity.java
@@ -124,6 +124,12 @@ public class FavouritesActivity extends AppCompatActivity {
         mKeyState[19] = mSharedPreferences.getBoolean(EXCEL_TO_PDF_KEY, false);
         mKeyState[20] = mSharedPreferences.getBoolean(ZIP_TO_PDF_KEY, false);
     }
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
 
     /**
      * Restore the initial state if user

--- a/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
@@ -71,6 +71,7 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
     private boolean mDoodleSelected = false;
     private PhotoEditor mPhotoEditor;
 
+    //每当用户点击菜单项跳转到其他页面时，要更新 currentPage 变量
     public static Intent getStartIntent(Context context, ArrayList<String> uris) {
         Intent intent = new Intent(context, ImageEditor.class);
         intent.putExtra(IMAGE_EDITOR_KEY, uris);

--- a/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
@@ -73,6 +73,7 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
 
     //每当用户点击菜单项跳转到其他页面时，要更新 currentPage 变量
     //每当用户点击菜单项跳转到其他页面时，要更新 currentPage 变量
+    //AndroidManifest.xml 中包含这些活动
     public static Intent getStartIntent(Context context, ArrayList<String> uris) {
         Intent intent = new Intent(context, ImageEditor.class);
         intent.putExtra(IMAGE_EDITOR_KEY, uris);

--- a/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImageEditor.java
@@ -72,6 +72,7 @@ public class ImageEditor extends AppCompatActivity implements OnFilterItemClicke
     private PhotoEditor mPhotoEditor;
 
     //每当用户点击菜单项跳转到其他页面时，要更新 currentPage 变量
+    //每当用户点击菜单项跳转到其他页面时，要更新 currentPage 变量
     public static Intent getStartIntent(Context context, ArrayList<String> uris) {
         Intent intent = new Intent(context, ImageEditor.class);
         intent.putExtra(IMAGE_EDITOR_KEY, uris);

--- a/app/src/main/java/swati4star/createpdf/activity/ImagesPreviewActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/ImagesPreviewActivity.java
@@ -33,6 +33,13 @@ public class ImagesPreviewActivity extends AppCompatActivity {
         return intent;
     }
 
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         ThemeUtils.getInstance().setThemeApp(this);

--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -139,6 +139,10 @@ public class MainActivity extends AppCompatActivity
         actionBar.setHomeAsUpIndicator(R.drawable.ic_menu);
         if (actionBar != null)
             actionBar.show();
+
+        //在每个页面的 onResume 方法中调用更新高亮的方法，以确保每次页面回到前台时都能更新状态。
+            updateNavigationHighlight(); // 更新高亮状态
+
     }
 
     @Override
@@ -442,6 +446,13 @@ public class MainActivity extends AppCompatActivity
             setTitle(title);
     }
 
+    //清除高亮状态
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     private void setThemeOnActivityExclusiveComponents() {
         RelativeLayout toolbarBackgroundLayout = findViewById(R.id.toolbar_background_layout);
         MaterialCardView content = findViewById(R.id.content);

--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -60,6 +60,9 @@ public class MainActivity extends AppCompatActivity
     private SparseIntArray mFragmentSelectedMap;
     private FragmentManagement mFragmentManagement;
 
+    //在主活动中，添加一个变量来跟踪当前页面
+    private String currentPage = "home"; // 默认页面
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         ThemeUtils.getInstance().setThemeApp(this);

--- a/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/MainActivity.java
@@ -254,6 +254,21 @@ public class MainActivity extends AppCompatActivity
         mNavigationView.setCheckedItem(id);
     }
 
+    //在导航菜单的点击事件中，更新 currentPage 变量，并调用更新高亮的方法：
+    @Override
+    public void onNavigationItemSelected(int position) {
+        switch (position) {
+            case 0: // 首页
+                currentPage = "home";
+                break;
+            case 1: // 设置
+                currentPage = "settings";
+                break;
+            // 添加其他页面的情况
+        }
+        updateNavigationHighlight();
+    }
+
     @Override
     protected void onStart() {
         super.onStart();

--- a/app/src/main/java/swati4star/createpdf/activity/PreviewActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/PreviewActivity.java
@@ -41,6 +41,20 @@ public class PreviewActivity extends AppCompatActivity implements PreviewImageOp
         intent.putExtra(PREVIEW_IMAGES, uris);
         return intent;
     }
+    @Override
+    public void onNavigationItemSelected(int position) {
+        switch (position) {
+            case 0: // 首页
+                currentPage = "home";
+                startActivity(new Intent(this, HomeActivity.class));
+                break;
+            case 1: // 设置
+                currentPage = "settings";
+                startActivity(new Intent(this, SettingsActivity.class));
+                break;
+            // 添加其他页面的情况
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/swati4star/createpdf/activity/RearrangeImages.java
+++ b/app/src/main/java/swati4star/createpdf/activity/RearrangeImages.java
@@ -72,6 +72,13 @@ public class RearrangeImages extends AppCompatActivity implements RearrangeImage
         recyclerView.setAdapter(mRearrangeImagesAdapter);
     }
 
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     @Override
     public void onUpClick(int position) {
         mImages.add(position - 1, mImages.remove(position));

--- a/app/src/main/java/swati4star/createpdf/activity/SplashActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/SplashActivity.java
@@ -13,4 +13,11 @@ public class SplashActivity extends AppCompatActivity {
         startActivity(new Intent(SplashActivity.this, MainActivity.class));
         finish();
     }
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
 }

--- a/app/src/main/java/swati4star/createpdf/activity/WelcomeActivity.java
+++ b/app/src/main/java/swati4star/createpdf/activity/WelcomeActivity.java
@@ -50,6 +50,13 @@ public class WelcomeActivity extends AppCompatActivity {
         }
     };
 
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         ThemeUtils.getInstance().setThemeApp(this);

--- a/app/src/main/java/swati4star/createpdf/adapter/HistoryAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/HistoryAdapter.java
@@ -40,6 +40,13 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.ViewHist
         mIconsOperationList.put(mActivity.getString(R.string.decrypted), R.drawable.ic_lock_open_black_24dp);
     }
 
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     @NonNull
     @Override
     public ViewHistoryHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeFilesAdapter.java
@@ -37,6 +37,13 @@ public class MergeFilesAdapter extends RecyclerView.Adapter<MergeFilesAdapter.Vi
         this.mIsMergeFragment = mIsMergeFragment;
     }
 
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     @NonNull
     @Override
     public ViewMergeFilesHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/java/swati4star/createpdf/adapter/MergeSelectedFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/MergeSelectedFilesAdapter.java
@@ -31,6 +31,13 @@ public class MergeSelectedFilesAdapter extends
         this.mOnClickListener = mOnClickListener;
     }
 
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     @NonNull
     @Override
     public MergeSelectedFilesHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/java/swati4star/createpdf/adapter/RecentListAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/RecentListAdapter.java
@@ -30,6 +30,13 @@ public class RecentListAdapter extends RecyclerView.Adapter<RecentListAdapter.Re
     }
 
 
+
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
     /**
      * Updates the recent list
      *

--- a/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
+++ b/app/src/main/java/swati4star/createpdf/adapter/ViewFilesAdapter.java
@@ -95,6 +95,13 @@ public class ViewFilesAdapter extends RecyclerView.Adapter<ViewFilesAdapter.View
         mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(mActivity);
     }
 
+    private void clearHighlights() {
+        // 例如，重置所有菜单项的背景或文本颜色
+        homeMenuItem.setBackgroundColor(defaultColor);
+        settingsMenuItem.setBackgroundColor(defaultColor);
+        // 添加其他菜单项
+    }
+
     @NonNull
     @Override
     public ViewFilesHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {

--- a/app/src/main/res/layout/fav_pref_screen.xml
+++ b/app/src/main/res/layout/fav_pref_screen.xml
@@ -23,4 +23,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp" />
+
+    <item
+            android:id="@+id/nav_home"
+            android:title="Home" />
+    <item
+            android:id="@+id/nav_settings"
+            android:title="Settings" />
 </LinearLayout>


### PR DESCRIPTION
# 问题解决
想要实现菜单栏高亮页面的转换，我的解决办法是设置一个变量来跟踪当前页面，进入java/swati4star/createpdf/activity 目录下，新创建一个BaseActivity基类，在这里实现所有与highlight相关的操作。创建一个标志性变量currentPage （home默认页面），实现在导航菜单的点击事件中，更新 currentPage 变量，并调用更新高亮的方法（onNavigationItemSelected()）要与Resources下的Layout中的.xml布局文件相连接，由于社区中有人提出页面切换不能实现高亮与之对应，因此后续又完善了updateNavigationHighlight() 方法实现了highlight与page的联调。此外，还在BaseActivity中添加了重置高亮的方法clearHighlights ()，最后完善资源配置文件，drawer_menu.xml (菜单资源)以及AndroidManifest.xml。

